### PR TITLE
feat: YellowCard USDC offramp

### DIFF
--- a/constants/yellowcard.ts
+++ b/constants/yellowcard.ts
@@ -1,0 +1,34 @@
+/**
+ * YellowCard off-ramp config. The off-ramp (Skip Go bridge + YC
+ * directSettlement) is mainnet-only — sandbox has neither Skip routes nor YC
+ * webhooks — so there is a single production worker URL.
+ */
+export const YELLOWCARD_WORKER_API = (process.env.NEXT_PUBLIC_YELLOWCARD_WORKER_API || 'https://yellowcard.worker.ixo.earth').trim();
+
+/** Skip Go API base — proxied through the worker so the Skip API key stays
+ *  server-side. */
+export const SKIP_API_URL = `${YELLOWCARD_WORKER_API}/skip`;
+
+/** ixo mainnet chain-id — Skip's `sourceAssetChainId`. The off-ramp only works
+ *  on this network. */
+export const IXO_CHAIN_ID = 'ixo-5';
+
+/** USDC IBC denom on ixo (Skip's `sourceAssetDenom`). This is the canonical
+ *  mainnet USDC, confirmed Skip-routable on ixo-5. A user may instead hold an
+ *  alternate USDC denom; the screen passes whichever denom the balance actually
+ *  uses, falling back to this. */
+export const IXO_USDC_DENOM = 'ibc/6BBE9BD4246F8E04948D5A4EEE7164B2630263B9EBB5E7DC5F0A46C62A2FF97B';
+
+/**
+ * Off-ramp destination: Base (cheapest/fastest EVM CCTP leg YC supports).
+ * `cryptoNetwork` is what YC expects; `skipChainId`/`skipDenom` are what Skip
+ * routes to (chain 8453, native USDC, checksummed denom).
+ */
+export const OFFRAMP_DESTINATION = {
+  cryptoNetwork: 'BASE',
+  skipChainId: '8453',
+  skipDenom: '0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913',
+};
+
+/** Off-ramp end-states (mirror the worker). Anything else is still in-flight. */
+export const TERMINAL_OFFRAMP_STATUSES = new Set(['completed', 'failed', 'expired', 'refunded', 'refund_failed', 'cancelled']);

--- a/hooks/useOfframp.ts
+++ b/hooks/useOfframp.ts
@@ -1,0 +1,285 @@
+import { useCallback, useState } from 'react';
+
+import { IXO_CHAIN_ID, OFFRAMP_DESTINATION } from '@constants/yellowcard';
+import { useAuth } from '@hooks/useAuth';
+import { type BridgeRoute, buildBridgeTx, getBridgeRoute, trackTx } from 'lib/skip/skipBridge';
+import {
+  type CreateResult,
+  type OfframpCustomer,
+  type OfframpDestination,
+  type OfframpTransaction,
+  type QuoteResult,
+  createOfframp,
+  fetchPaymentRecordPdf,
+  getOfframp,
+  listOfframps,
+  notifyDeposit,
+  quoteOfframp,
+} from 'lib/yellowcard/offrampClient';
+import { mintOfframpBearer } from '@utils/ucanYellowcard';
+
+const USDC_DECIMALS = 6;
+
+function toMicro(amount: number): string {
+  return Math.floor(amount * 10 ** USDC_DECIMALS).toString();
+}
+
+/** The address to provide for a chain Skip lists in `requiredChainAddresses`.
+ *  ixo USDC → Base only requires ixo + Base (CCTP routes through Noble without
+ *  needing a Noble address). We provide only those two and THROW on anything
+ *  else — if Skip starts requiring another hop, abort rather than guess an
+ *  address. */
+function addressForRequiredChain(chainId: string, ixoAddress: string, destinationAddress: string): string {
+  if (chainId === OFFRAMP_DESTINATION.skipChainId) return destinationAddress;
+  if (chainId === IXO_CHAIN_ID) return ixoAddress;
+  throw new Error(
+    `Skip route unexpectedly requires an address for chain "${chainId}" (expected only ${IXO_CHAIN_ID} + ${OFFRAMP_DESTINATION.skipChainId}). Aborting for safety.`,
+  );
+}
+
+/** In-flight stage of a withdrawal, for UI feedback. */
+export type OfframpStage = 'idle' | 'authorizing' | 'creating' | 'bridging' | 'notifying' | 'submitted' | 'error';
+
+export interface WithdrawParams {
+  /** Whole USDC the user SENDS from ixo (bridged via Skip). The YC sell is
+   *  created for the amount that ACTUALLY arrives, recomputed at withdraw time
+   *  (the user may have waited after quoting). */
+  amountUsdc: number;
+  currency: string;
+  /** Payout rail (bank|momo) — YC auto-routes to the best channel. */
+  channelType: string;
+  /** The exact ixo USDC denom the user holds (Skip source asset). */
+  sourceDenom?: string;
+  customer: OfframpCustomer;
+  destination: OfframpDestination;
+}
+
+/** Preview combining BOTH legs: the Skip bridge (ixo→Base) fee and the YC
+ *  quote, taken on the amount that actually ARRIVES after the bridge. */
+export interface WithdrawalPreview {
+  quote: QuoteResult;
+  sendUsdc: number;
+  bridgedUsdc: number;
+  skipFeeUsd: number;
+}
+
+/**
+ * YellowCard off-ramp orchestration for jambo. Uses the auth-hub session-key
+ * signer (`useAuth().onSign`) for the single bridge transaction — jambo has
+ * one signing path, so there's no passkey/SignX branching. Each worker call is
+ * authorised with a freshly-minted UCAN invocation (no PIN prompt: the Ed25519
+ * key is already in secure storage post-login).
+ */
+export default function useOfframp() {
+  const { address, did, onSign } = useAuth();
+
+  const [stage, setStage] = useState<OfframpStage>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [transactions, setTransactions] = useState<OfframpTransaction[]>([]);
+  const [active, setActive] = useState<CreateResult | null>(null);
+  const [bridgeRoute, setBridgeRoute] = useState<BridgeRoute | null>(null);
+
+  const mintBearer = useCallback(async (): Promise<string> => {
+    if (!did) throw new Error('Not signed in');
+    return mintOfframpBearer(did);
+  }, [did]);
+
+  const refreshTransactions = useCallback(async () => {
+    const bearer = await mintBearer();
+    const res = await listOfframps(bearer);
+    setTransactions(res.transactions);
+    return res.transactions;
+  }, [mintBearer]);
+
+  /** Price the Skip bridge (ixo→Base) — how much USDC survives the hop. */
+  const quoteBridge = useCallback(
+    async (amountUsdc: number, sourceDenom?: string): Promise<BridgeRoute> => {
+      const r = await getBridgeRoute({ amountInMicro: toMicro(amountUsdc), sourceDenom });
+      setBridgeRoute(r);
+      return r;
+    },
+    [],
+  );
+
+  /** Build the Skip messages, broadcast the ixo tx via the session-key signer,
+   *  then register it with Skip's relay. Returns the ixo source tx hash. */
+  const sendBridge = useCallback(
+    async (params: { amountUsdc: number; destinationAddress: string; sourceDenom?: string; route?: BridgeRoute }): Promise<string> => {
+      if (!address) throw new Error('Wallet address not available');
+      const amountInMicro = toMicro(params.amountUsdc);
+
+      const r = params.route ?? (await quoteBridge(params.amountUsdc, params.sourceDenom));
+      const chainIdsToAddresses: Record<string, string> = {};
+      for (const chainId of r.requiredChainAddresses) {
+        chainIdsToAddresses[chainId] = addressForRequiredChain(chainId, address, params.destinationAddress);
+      }
+
+      const { chainId, msgs } = await buildBridgeTx({ amountInMicro, sourceDenom: params.sourceDenom, chainIdsToAddresses });
+
+      // jambo's session-key signer wraps the messages with the smart-account
+      // TxExtension and broadcasts; the auth provider shows the signing modal.
+      const result = await onSign(msgs);
+      const hash = result?.transactionHash;
+      if (!hash) throw new Error('No transaction hash returned from signing');
+
+      await trackTx(chainId, hash).catch(() => undefined);
+      return hash;
+    },
+    [address, onSign, quoteBridge],
+  );
+
+  /** Preview a withdrawal end-to-end: price the bridge, then quote YC on the
+   *  amount that actually arrives so `fiatReceived` is net of both fees. */
+  const previewWithdrawal = useCallback(
+    async (params: { amountUsdc: number; currency: string; channelType: string; country: string; sourceDenom?: string }): Promise<WithdrawalPreview> => {
+      const route = await quoteBridge(params.amountUsdc, params.sourceDenom);
+      const bridgedUsdc = Number(route.amountOutMicro) / 1e6;
+      const skipFeeUsd =
+        route.usdAmountIn != null && route.usdAmountOut != null
+          ? Math.max(0, Number(route.usdAmountIn) - Number(route.usdAmountOut))
+          : Math.max(0, params.amountUsdc - bridgedUsdc);
+      const bearer = await mintBearer();
+      const quote = await quoteOfframp(
+        {
+          cryptoAmount: bridgedUsdc,
+          currency: params.currency,
+          channelType: params.channelType,
+          country: params.country,
+          network: OFFRAMP_DESTINATION.cryptoNetwork,
+        },
+        bearer,
+      );
+      return { quote, sendUsdc: params.amountUsdc, bridgedUsdc, skipFeeUsd };
+    },
+    [quoteBridge, mintBearer],
+  );
+
+  /**
+   * Full off-ramp:
+   *  1. authorize (UCAN) + create the YC sell → get the crypto deposit address;
+   *  2. bridge the user's ixo USDC to that address via Skip (user signs);
+   *  3. notify the worker of the source tx so it can track to completion.
+   */
+  const withdraw = useCallback(
+    async (params: WithdrawParams): Promise<CreateResult> => {
+      setError(null);
+      try {
+        setStage('authorizing');
+        const createBearer = await mintBearer();
+
+        // Re-price the Skip bridge NOW so the YC sell is created for the amount
+        // that will ACTUALLY arrive. The same route is reused for the broadcast
+        // below — no drift between what YC expects and what we send.
+        setStage('creating');
+        const route = await quoteBridge(params.amountUsdc, params.sourceDenom);
+        const arrivingUsdc = Number(route.amountOutMicro) / 1e6;
+        const skipFeeUsd =
+          route.usdAmountIn != null && route.usdAmountOut != null
+            ? Math.max(0, Number(route.usdAmountIn) - Number(route.usdAmountOut))
+            : Math.max(0, params.amountUsdc - arrivingUsdc);
+
+        const created = await createOfframp(
+          {
+            cryptoAmount: arrivingUsdc,
+            sendAmountUsdc: params.amountUsdc,
+            skipFeeUsd,
+            currency: params.currency,
+            channelType: params.channelType,
+            network: OFFRAMP_DESTINATION.cryptoNetwork,
+            customer: params.customer,
+            destination: params.destination,
+          },
+          createBearer,
+        );
+        setActive(created);
+        void refreshTransactions().catch(() => undefined);
+
+        if (!created.deposit_address) {
+          throw new Error('YellowCard did not return a deposit address for this sell. Check the worker logs.');
+        }
+
+        setStage('bridging');
+        const sourceTxHash = await sendBridge({
+          amountUsdc: params.amountUsdc,
+          destinationAddress: created.deposit_address,
+          sourceDenom: params.sourceDenom,
+          route,
+        });
+
+        if (sourceTxHash) {
+          setStage('notifying');
+          const depositBearer = await mintBearer();
+          await notifyDeposit(created.id, { skipTxHash: sourceTxHash, skipStatus: 'broadcast' }, depositBearer);
+        }
+
+        setStage('submitted');
+        await refreshTransactions().catch(() => undefined);
+        return created;
+      } catch (err) {
+        setStage('error');
+        setError(err instanceof Error ? err.message : 'Withdrawal failed');
+        throw err;
+      }
+    },
+    [mintBearer, quoteBridge, sendBridge, refreshTransactions],
+  );
+
+  /** Re-run ONLY the bridge leg for an existing sell whose YC settlement is
+   *  still open (deposit address unchanged), for when the first attempt was
+   *  cancelled / failed before the crypto reached YellowCard. */
+  const retryBridge = useCallback(
+    async (tx: OfframpTransaction, sourceDenom?: string): Promise<void> => {
+      if (!tx.deposit_address) throw new Error('No deposit address on this withdrawal.');
+      const amountUsdc = tx.send_amount_usdc ?? tx.amount_usd;
+      if (amountUsdc == null) throw new Error('Unknown send amount for this withdrawal.');
+      setError(null);
+      try {
+        const route = await quoteBridge(amountUsdc, sourceDenom);
+        const sourceTxHash = await sendBridge({ amountUsdc, destinationAddress: tx.deposit_address, sourceDenom, route });
+        if (sourceTxHash) {
+          const bearer = await mintBearer();
+          await notifyDeposit(tx.id, { skipTxHash: sourceTxHash, skipStatus: 'broadcast' }, bearer);
+        }
+        await refreshTransactions().catch(() => undefined);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Retry failed');
+        throw err;
+      }
+    },
+    [quoteBridge, sendBridge, mintBearer, refreshTransactions],
+  );
+
+  const pollTransaction = useCallback(
+    async (id: string): Promise<OfframpTransaction> => {
+      const bearer = await mintBearer();
+      const res = await getOfframp(id, bearer);
+      return res.transaction;
+    },
+    [mintBearer],
+  );
+
+  const downloadPaymentRecord = useCallback(
+    async (id: string): Promise<Blob> => {
+      const bearer = await mintBearer();
+      return fetchPaymentRecordPdf(id, bearer);
+    },
+    [mintBearer],
+  );
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return {
+    stage,
+    error,
+    active,
+    transactions,
+    bridgeRoute,
+    previewWithdrawal,
+    withdraw,
+    retryBridge,
+    refreshTransactions,
+    pollTransaction,
+    downloadPaymentRecord,
+    clearError,
+  };
+}

--- a/lib/authHub/redirect.ts
+++ b/lib/authHub/redirect.ts
@@ -14,10 +14,21 @@ export interface AuthHubSessionData {
 
 /**
  * Redirect to the auth hub for login.
+ *
+ * `hideMnemonic` (default true) appends `hide_mnemonic=true`, which tells the
+ * auth hub to skip the recovery-phrase ("Secret Words") screen during
+ * registration. jambo owns backup/recovery itself — the root mnemonic is stored
+ * encrypted in the user's Matrix room state (PIN-gated) — so the raw phrase
+ * never needs to be surfaced during sign-up. The mnemonic is still generated and
+ * stored server-side; only its display is skipped.
  */
-export function loginViaAuthHub() {
+export function loginViaAuthHub(options?: { hideMnemonic?: boolean }) {
   const redirectUri = `${window.location.origin}/auth/callback`;
-  window.location.href = `${AUTH_HUB_URL}/api/auth/login?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  let url = `${AUTH_HUB_URL}/api/auth/login?redirect_uri=${encodeURIComponent(redirectUri)}`;
+  if (options?.hideMnemonic ?? true) {
+    url += '&hide_mnemonic=true';
+  }
+  window.location.href = url;
 }
 
 /**

--- a/lib/skip/skipBridge.ts
+++ b/lib/skip/skipBridge.ts
@@ -1,0 +1,186 @@
+import { ibc } from '@ixo/impactxclient-sdk';
+
+import { IXO_CHAIN_ID, IXO_USDC_DENOM, OFFRAMP_DESTINATION, SKIP_API_URL } from '@constants/yellowcard';
+
+/**
+ * Skip Go bridge — ixo USDC → Base USDC — WITHOUT Skip's `executeRoute`.
+ *
+ * ixo accounts are smart accounts: a tx is only valid when jambo's signing
+ * client wraps it with the session authenticator (`signAndBroadcastWithSessionKey`,
+ * surfaced as `useAuth().onSign`). Skip's `executeRoute` builds its own vanilla
+ * client, so it can't broadcast for ixo. Instead we ask Skip for the messages
+ * (`/v2/fungible/msgs_direct`), broadcast the ixo tx ourselves via `onSign`,
+ * then tell Skip to relay (`/v2/tx/track`) and poll (`/v2/tx/status`).
+ *
+ * Everything here is plain `fetch` against the worker's `/skip` proxy — no
+ * `@skip-go/client` dependency.
+ */
+
+const ROUTE = `${SKIP_API_URL}/v2/fungible/route`;
+const MSGS_DIRECT = `${SKIP_API_URL}/v2/fungible/msgs_direct`;
+const TRACK = `${SKIP_API_URL}/v2/tx/track`;
+const STATUS = `${SKIP_API_URL}/v2/tx/status`;
+
+/** A CosmJS-encodable message (typeUrl + decoded value). */
+export interface TrxMsg {
+  typeUrl: string;
+  value: any;
+}
+
+export interface BridgeRoute {
+  amountInMicro: string;
+  amountOutMicro: string;
+  usdAmountIn?: string;
+  usdAmountOut?: string;
+  estimatedDurationSeconds?: number;
+  requiredChainAddresses: string[];
+  /** Raw Skip route, for the msgs_direct call / debugging. */
+  raw: unknown;
+}
+
+/** Quote-only: estimated output + USD + duration for display. Reads the Skip
+ *  REST shape (snake_case) returned by the worker proxy. */
+export async function getBridgeRoute(params: { amountInMicro: string; sourceDenom?: string }): Promise<BridgeRoute> {
+  const res = await fetch(ROUTE, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      amount_in: params.amountInMicro,
+      source_asset_chain_id: IXO_CHAIN_ID,
+      source_asset_denom: params.sourceDenom ?? IXO_USDC_DENOM,
+      dest_asset_chain_id: OFFRAMP_DESTINATION.skipChainId,
+      dest_asset_denom: OFFRAMP_DESTINATION.skipDenom,
+      smart_relay: true,
+      // Allow routes that fail the USD price-safety check — on small amounts the
+      // relay/CCTP fees make output < input by enough to trip it. The user
+      // accepts the cost shown in the quote.
+      allow_unsafe: true,
+    }),
+  });
+  const json = await res.json().catch(() => null);
+  if (!res.ok || !json) {
+    throw new Error(json?.message || json?.error || `Skip found no route for ixo USDC → Base USDC (try a different amount).`);
+  }
+  return {
+    amountInMicro: params.amountInMicro,
+    amountOutMicro: json.amount_out ?? json.estimated_amount_out ?? '0',
+    usdAmountIn: json.usd_amount_in,
+    usdAmountOut: json.usd_amount_out,
+    estimatedDurationSeconds: json.estimated_route_duration_seconds,
+    requiredChainAddresses: json.required_chain_addresses ?? [],
+    raw: json,
+  };
+}
+
+interface WireCosmosMsg {
+  msg?: string;
+  msg_type_url?: string;
+  msgTypeUrl?: string;
+}
+interface WireCosmosTx {
+  chain_id?: string;
+  chainId?: string;
+  signer_address?: string;
+  msgs?: WireCosmosMsg[];
+}
+
+/** Convert one Skip cosmos message (proto3-JSON string) into a CosmJS
+ *  EncodeObject the ixo signing client can encode. The ixo source tx is a
+ *  single IBC `MsgTransfer` (with a CCTP-forward memo); other types fall
+ *  through as parsed JSON. */
+function toTrxMsg(m: WireCosmosMsg): TrxMsg {
+  const typeUrl = m.msg_type_url ?? m.msgTypeUrl ?? '';
+  const v = m.msg ? (JSON.parse(m.msg) as Record<string, any>) : {};
+  if (typeUrl.endsWith('MsgTransfer')) {
+    const th = (v.timeout_height ?? v.timeoutHeight) as Record<string, any> | undefined;
+    const value = ibc.applications.transfer.v1.MsgTransfer.fromPartial({
+      sourcePort: v.source_port ?? v.sourcePort ?? 'transfer',
+      sourceChannel: v.source_channel ?? v.sourceChannel,
+      token: v.token,
+      sender: v.sender,
+      receiver: v.receiver,
+      timeoutHeight: th
+        ? { revisionNumber: th.revision_number ?? th.revisionNumber ?? '0', revisionHeight: th.revision_height ?? th.revisionHeight ?? '0' }
+        : undefined,
+      timeoutTimestamp: v.timeout_timestamp ?? v.timeoutTimestamp ?? '0',
+      memo: v.memo ?? '',
+    });
+    return { typeUrl, value };
+  }
+  return { typeUrl, value: v };
+}
+
+export interface BridgeTx {
+  chainId: string;
+  msgs: TrxMsg[];
+}
+
+/** Ask Skip for the exact messages to broadcast. `chainIdsToAddresses` must
+ *  cover every chain in the path (ixo source, Base dest — CCTP routes through
+ *  Noble without needing a Noble address). */
+export async function buildBridgeTx(params: {
+  amountInMicro: string;
+  sourceDenom?: string;
+  chainIdsToAddresses: Record<string, string>;
+}): Promise<BridgeTx> {
+  const res = await fetch(MSGS_DIRECT, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      source_asset_denom: params.sourceDenom ?? IXO_USDC_DENOM,
+      source_asset_chain_id: IXO_CHAIN_ID,
+      dest_asset_denom: OFFRAMP_DESTINATION.skipDenom,
+      dest_asset_chain_id: OFFRAMP_DESTINATION.skipChainId,
+      amount_in: params.amountInMicro,
+      chain_ids_to_addresses: params.chainIdsToAddresses,
+      slippage_tolerance_percent: '1',
+      smart_relay: true,
+      allow_unsafe: true,
+    }),
+  });
+  const json = await res.json();
+  if (!res.ok) throw new Error(json?.message || json?.error || `Skip msgs_direct ${res.status}`);
+  const txs: Array<{ cosmos_tx?: WireCosmosTx; cosmosTx?: WireCosmosTx }> = json?.txs ?? [];
+  const cosmos = txs
+    .map((t) => t.cosmos_tx ?? t.cosmosTx)
+    .find((t): t is WireCosmosTx => !!t && (t.chain_id === IXO_CHAIN_ID || t.chainId === IXO_CHAIN_ID));
+  if (!cosmos) throw new Error('Skip returned no ixo transaction to sign');
+  const msgs = (cosmos.msgs ?? []).map(toTrxMsg);
+  return { chainId: IXO_CHAIN_ID, msgs };
+}
+
+/** Register the broadcast tx with Skip so Smart Relay completes the route.
+ *  Right after broadcast the tx often isn't indexed on Skip's RPC yet
+ *  ("tx not found"), so retry with backoff before giving up. */
+export async function trackTx(chainId: string, txHash: string, attempts = 8, delayMs = 4000): Promise<void> {
+  let lastErr: unknown = null;
+  for (let i = 0; i < attempts; i++) {
+    const res = await fetch(TRACK, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ chain_id: chainId, tx_hash: txHash }),
+    });
+    if (res.ok) return;
+    const json = await res.json().catch(() => null);
+    const msg = String(json?.message ?? json?.error ?? `Skip track ${res.status}`);
+    lastErr = new Error(msg);
+    // Retry only the propagation case; fail fast on anything else.
+    if (!/not found/i.test(msg)) throw lastErr;
+    await new Promise((r) => setTimeout(r, delayMs));
+  }
+  throw lastErr ?? new Error('Skip track failed');
+}
+
+export interface BridgeStatus {
+  state: string;
+  raw: unknown;
+}
+
+/** Poll Skip for the cross-chain transfer state. */
+export async function getStatus(chainId: string, txHash: string): Promise<BridgeStatus> {
+  const url = `${STATUS}?chain_id=${encodeURIComponent(chainId)}&tx_hash=${encodeURIComponent(txHash)}`;
+  const res = await fetch(url);
+  const json = await res.json().catch(() => null);
+  if (!res.ok) throw new Error(json?.message || `Skip status ${res.status}`);
+  return { state: String(json?.state ?? json?.status ?? 'unknown'), raw: json };
+}

--- a/lib/yellowcard/offrampClient.ts
+++ b/lib/yellowcard/offrampClient.ts
@@ -1,0 +1,245 @@
+import { YELLOWCARD_WORKER_API } from '@constants/yellowcard';
+
+/**
+ * Thin client for the YellowCard worker's off-ramp endpoints. The off-ramp
+ * routes are UCAN-gated (rootMode 'any') — pass a freshly-minted invocation
+ * CAR as the bearer. `/channels` and `/countries` are public.
+ */
+
+const BASE = YELLOWCARD_WORKER_API.replace(/\/+$/, '');
+
+export interface OfframpCustomer {
+  name: string;
+  country: string;
+  phone?: string;
+  email?: string;
+  address?: string;
+  dob?: string;
+  idType?: string;
+  idNumber?: string;
+  additionalIdNumber?: string;
+}
+
+export interface OfframpDestination {
+  accountName: string;
+  accountNumber: string;
+  accountType: 'bank' | 'momo';
+  networkId: string;
+  country: string;
+  bankName?: string;
+}
+
+export interface OfframpTransaction {
+  id: string;
+  status: string;
+  yc_payment_id: string | null;
+  crypto_currency: string;
+  crypto_network: string;
+  deposit_address: string | null;
+  /** USDC the user sent from ixo (pre Skip bridge). */
+  send_amount_usdc: number | null;
+  /** Skip bridge/relay fee (USD ≈ USDC). */
+  skip_fee_usd: number | null;
+  /** USDC that reached YC after the bridge. */
+  amount_usd: number | null;
+  local_currency: string | null;
+  local_amount: number | null;
+  converted_amount: number | null;
+  service_fee_usd: number | null;
+  partner_fee_usd: number | null;
+  rate: number | null;
+  /** YC settlement deadline (unix seconds) — bridge retry only valid before. */
+  expires_at: number | null;
+  destination: unknown;
+  channel_id: string | null;
+  /** Payout rail YC routed on ('bank' | 'momo'). */
+  channel_type: string | null;
+  /** Optional crypto refund address (Base) for a failed payout. */
+  refund_address: string | null;
+  skip_tx_hash: string | null;
+  skip_status: string | null;
+  /** YC's raw errorCode (e.g. NAME_MISMATCH) or failure reason. */
+  error: string | null;
+  /** Readable meaning of a YC errorCode, mapped server-side from YC's docs. */
+  error_detail: string | null;
+  created_at: number;
+  updated_at: number;
+}
+
+async function post<T>(path: string, body: unknown, bearer?: string): Promise<T> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  if (bearer) headers.Authorization = `Bearer ${bearer}`;
+  const res = await fetch(`${BASE}${path}`, { method: 'POST', headers, body: JSON.stringify(body) });
+  const text = await res.text();
+  const json = text ? JSON.parse(text) : null;
+  if (!res.ok) {
+    throw new Error(json?.message || json?.error || `Worker ${path} returned ${res.status}`);
+  }
+  return json as T;
+}
+
+async function get<T>(path: string, bearer: string): Promise<T> {
+  const res = await fetch(`${BASE}${path}`, { headers: { Authorization: `Bearer ${bearer}` } });
+  const text = await res.text();
+  const json = text ? JSON.parse(text) : null;
+  if (!res.ok) {
+    throw new Error(json?.message || json?.error || `Worker ${path} returned ${res.status}`);
+  }
+  return json as T;
+}
+
+export interface QuoteResult {
+  success: true;
+  currency: string;
+  cryptoAmount: number;
+  network: string;
+  fiatReceived?: number;
+  convertedAmount?: number;
+  rateLocal?: number;
+  serviceFeeLocal?: number;
+  serviceFeeUSD?: number;
+  partnerFeeLocal?: number;
+  partnerFeeUSD?: number;
+  paymentMethod?: string;
+  /** Min/max the user may sell, in USDC. */
+  cryptoMinLimit?: number | null;
+  cryptoMaxLimit?: number | null;
+  /** Min/max in local currency. */
+  transactionLimitMin?: number | null;
+  transactionLimitMax?: number | null;
+}
+
+export function quoteOfframp(
+  body: { cryptoAmount: number; currency: string; channelType: string; country: string; network?: string },
+  bearer: string,
+): Promise<QuoteResult> {
+  return post<QuoteResult>('/offramp/quote', body, bearer);
+}
+
+export interface CreateResult {
+  success: true;
+  id: string;
+  status: string;
+  yc_payment_id: string | null;
+  deposit_address: string | null;
+  crypto_network: string;
+  crypto_currency: string;
+  send_amount_usdc: number | null;
+  skip_fee_usd: number | null;
+  amount_usd: number | null;
+  local_currency: string | null;
+  local_amount: number | null;
+  service_fee_usd: number | null;
+  partner_fee_usd: number | null;
+  expires_at: number | null;
+  created_at: number;
+}
+
+export function createOfframp(
+  body: {
+    // directSettlement sells take the exact USDC amount (→ settlementInfo.cryptoAmount).
+    cryptoAmount: number;
+    /** Full USDC the user sent from ixo (pre-bridge) + the bridge fee — stored
+     *  for history display only. */
+    sendAmountUsdc?: number;
+    skipFeeUsd?: number;
+    currency: string;
+    /** Payout rail — YC auto-routes to the optimal channel of this type. */
+    channelType: string;
+    network?: string;
+    customerType?: string;
+    customer: OfframpCustomer;
+    destination: OfframpDestination;
+  },
+  bearer: string,
+): Promise<CreateResult> {
+  return post<CreateResult>('/offramp/create', body, bearer);
+}
+
+export function notifyDeposit(
+  id: string,
+  body: { skipTxHash: string; skipStatus?: string },
+  bearer: string,
+): Promise<{ success: true; transaction: OfframpTransaction }> {
+  return post(`/offramp/${id}/deposit`, body, bearer);
+}
+
+/** Download the payment-record PDF for a COMPLETED off-ramp (worker returns
+ *  400 otherwise). The worker brands it "Proof of Payment"; for NG it includes
+ *  the bank's NIP session id. */
+export async function fetchPaymentRecordPdf(id: string, bearer: string): Promise<Blob> {
+  const res = await fetch(`${BASE}/offramp/${id}/proof`, { headers: { Authorization: `Bearer ${bearer}` } });
+  if (!res.ok) {
+    const text = await res.text();
+    let json: { message?: string; error?: string } | null = null;
+    try {
+      json = text ? JSON.parse(text) : null;
+    } catch {
+      /* non-JSON error body */
+    }
+    throw new Error(json?.message || json?.error || `Worker /offramp/${id}/proof returned ${res.status}`);
+  }
+  return res.blob();
+}
+
+export function listOfframps(bearer: string): Promise<{ success: true; count: number; transactions: OfframpTransaction[] }> {
+  return get(`/offramp/transactions`, bearer);
+}
+
+export function getOfframp(id: string, bearer: string): Promise<{ success: true; transaction: OfframpTransaction }> {
+  return get(`/offramp/${id}`, bearer);
+}
+
+// --- Public: channel/network discovery for the payout bank picker ---
+
+export interface YcNetwork {
+  id: string;
+  name?: string;
+  code?: string;
+  status?: string;
+  channelId?: string;
+  channelIds?: string[];
+}
+export interface YcChannel {
+  id: string;
+  currency?: string;
+  accountType?: string;
+  channelType?: string;
+  rampType?: string;
+  status?: string;
+  /** Whether the channel is usable by YC's widget quote — the worker only
+   *  returns channels with this 'active', since the quote depends on it. */
+  widgetStatus?: string;
+  /** API/submit-payment minimum (local currency) — the one YC enforces. */
+  min?: number;
+  max?: number;
+  /** Widget-flow limits — NOT what the API enforces (often lower). */
+  widgetMin?: number;
+  widgetMax?: number;
+  estimatedSettlementTime?: number;
+}
+
+/** Public: the YC-supported off-ramp country codes (ISO alpha-2). Maintained
+ *  server-side so the list can be updated without a frontend release. */
+export async function fetchSupportedCountries(): Promise<string[]> {
+  const res = await fetch(`${BASE}/countries`);
+  const text = await res.text();
+  const json = text ? JSON.parse(text) : null;
+  if (!res.ok) {
+    throw new Error(json?.message || json?.error || `Worker /countries returned ${res.status}`);
+  }
+  return Array.isArray(json?.countries) ? json.countries : [];
+}
+
+export async function discoverChannels(country: string): Promise<{ channels: YcChannel[]; networks: YcNetwork[] }> {
+  const json = await post<{ results?: Array<{ success?: boolean; country?: string; channels?: unknown; networks?: unknown }> }>('/channels', {
+    countries: [country.toUpperCase()],
+  });
+  const entry = (json.results ?? []).find((r) => r?.success);
+  const arr = (v: unknown): any[] =>
+    Array.isArray(v) ? v : Array.isArray((v as any)?.channels) ? (v as any).channels : Array.isArray((v as any)?.networks) ? (v as any).networks : [];
+  return {
+    channels: arr(entry?.channels) as YcChannel[],
+    networks: arr(entry?.networks) as YcNetwork[],
+  };
+}

--- a/pages/profile/offramp.tsx
+++ b/pages/profile/offramp.tsx
@@ -1,0 +1,10 @@
+import AuthGuard from '@components/AuthGuard';
+import OfframpScreen from 'screens/offramp';
+
+export default function OfframpPage() {
+  return (
+    <AuthGuard>
+      <OfframpScreen />
+    </AuthGuard>
+  );
+}

--- a/screens/offramp.tsx
+++ b/screens/offramp.tsx
@@ -1,0 +1,1168 @@
+import { type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useRouter } from 'next/router';
+
+import { BackgroundSetupContext } from '@contexts/backgroundSetup';
+import Header from '@components/Header/Header';
+import Loader from '@components/Loader/Loader';
+import Button, { BUTTON_BG_COLOR, BUTTON_BORDER_COLOR, BUTTON_COLOR, BUTTON_SIZE } from '@components/Button/Button';
+import { CHAIN_NETWORK_TYPE, DefaultChainNetwork } from '@constants/common';
+import { IXO_CHAIN_ID, TERMINAL_OFFRAMP_STATUSES } from '@constants/yellowcard';
+import { useAuth } from '@hooks/useAuth';
+import useOfframp from '@hooks/useOfframp';
+import { getStatus as getSkipStatus } from 'lib/skip/skipBridge';
+import {
+  type OfframpTransaction,
+  type QuoteResult,
+  type YcChannel,
+  type YcNetwork,
+  discoverChannels,
+  fetchSupportedCountries,
+} from 'lib/yellowcard/offrampClient';
+import { ALL_COUNTRY_OPTIONS, countryOptions } from '@utils/countries';
+import { type KycPrefill, hasKycCredential, loadKycPrefill } from '@utils/kycPrefill';
+import { type OfframpProfile, loadOfframpProfile, saveOfframpProfile } from '@utils/offrampProfile';
+import { getUsdcBalance } from '@utils/usdcBalance';
+
+import styles from '@styles/Offramp.module.scss';
+
+// Sender ID types — independent of the payout bank's country. NIN is not listed
+// here: it's auto-applied (with BVN) when the sender's own country is Nigeria.
+const ID_TYPE_OPTIONS = [
+  { value: 'passport', label: 'Passport' },
+  { value: 'national_id', label: 'National ID' },
+  { value: 'drivers_license', label: "Driver's license" },
+];
+
+// TEMP (testing only): set true to bypass the KYC-credential gate so the
+// withdraw form shows regardless of whether the user holds a KYC credential.
+// Leave false in production — withdrawals require a verified identity.
+const BYPASS_KYC_CHECK = false;
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const VERIFIED_LABEL = 'From your verified identity';
+const KYC_INFO_LABEL =
+  'We’ve filled in and locked the details from your verified identity. Complete any remaining fields below.';
+const ESTIMATE_NOTE =
+  'Estimated — the final payout can vary slightly with exchange-rate and fee changes at settlement.';
+
+function networkChannelIds(network: YcNetwork): string[] {
+  if (Array.isArray(network.channelIds)) return network.channelIds.filter(Boolean);
+  if (network.channelId) return [network.channelId];
+  return [];
+}
+
+function formatDob(value: string): string {
+  // <input type="date"> gives YYYY-MM-DD; YC expects MM/DD/YYYY.
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!m) return '';
+  return `${m[2]}/${m[3]}/${m[1]}`;
+}
+
+function formatUsdc(amount: number): string {
+  return amount.toLocaleString(undefined, { maximumFractionDigits: 6 });
+}
+
+export default function OfframpScreen() {
+  const router = useRouter();
+  const { address, did, matrixRoomId } = useAuth();
+  const { getMatrixClient, awaitCompletion } = useContext(BackgroundSetupContext);
+  const offramp = useOfframp();
+
+  const isMainnet = DefaultChainNetwork === CHAIN_NETWORK_TYPE.MAINNET;
+  // const isMainnet = true;
+
+  const [balance, setBalance] = useState<number | null>(null);
+  const [heldDenom, setHeldDenom] = useState<string | undefined>(undefined);
+  const [balanceLoading, setBalanceLoading] = useState(false);
+
+  const [amount, setAmount] = useState<string>('');
+  const [country, setCountry] = useState<string>('ZA');
+  const [supportedOptions, setSupportedOptions] = useState<{ value: string; label: string }[]>([]);
+  const [bankNetworks, setBankNetworks] = useState<YcNetwork[]>([]);
+  const [channels, setChannels] = useState<YcChannel[]>([]);
+  const [loadingBanks, setLoadingBanks] = useState(false);
+  const [networkId, setNetworkId] = useState<string>('');
+  const [accountNumber, setAccountNumber] = useState('');
+  const [accountName, setAccountName] = useState('');
+
+  const [kycName, setKycName] = useState('');
+  const [kycPhone, setKycPhone] = useState('');
+  const [kycEmail, setKycEmail] = useState('');
+  const [kycDob, setKycDob] = useState('');
+  const [kycCountry, setKycCountry] = useState('ZA');
+  const [kycIdType, setKycIdType] = useState('passport');
+  const [kycIdNumber, setKycIdNumber] = useState('');
+  const [kycBvn, setKycBvn] = useState('');
+
+  // Best-effort prefill from the user's verified identity (KYC credential + PII).
+  // Fields we resolve are locked; the rest stay editable.
+  const [prefill, setPrefill] = useState<KycPrefill | null>(null);
+  // KYC gate: null = still checking, true/false = whether they hold a credential.
+  const [hasKyc, setHasKyc] = useState<boolean | null>(null);
+  // Remembered fields from a previous withdrawal (editable, overridable). Lower
+  // priority than KYC prefill — only fills fields KYC didn't lock.
+  const [savedProfile, setSavedProfile] = useState<OfframpProfile | null>(null);
+  const appliedSavedRef = useRef(false);
+  // Saved bank id waiting to be applied once this country's bank list loads.
+  const [pendingBankId, setPendingBankId] = useState<string | null>(null);
+
+  const [quote, setQuote] = useState<QuoteResult | null>(null);
+  const [quoting, setQuoting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [expandedTxId, setExpandedTxId] = useState<string | null>(null);
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+  const [downloadingRecordId, setDownloadingRecordId] = useState<string | null>(null);
+  const [skipStatuses, setSkipStatuses] = useState<Record<string, string>>({});
+
+  const isNG = kycCountry === 'NG';
+  // Effective KYC gate — forced open when the testing bypass is on.
+  const kycGate: boolean | null = BYPASS_KYC_CHECK ? true : hasKyc;
+
+  // Balance (canonical mainnet USDC denom).
+  useEffect(() => {
+    if (!isMainnet || !address) return;
+    let cancelled = false;
+    setBalanceLoading(true);
+    getUsdcBalance(address)
+      .then((b) => {
+        if (cancelled) return;
+        setBalance(b.amount);
+        setHeldDenom(b.denom);
+      })
+      .finally(() => {
+        if (!cancelled) setBalanceLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [isMainnet, address]);
+
+  // Best-effort: load the user's verified KYC identity (matrix must be ready).
+  // Any failure (no credential, undecryptable, matrix not ready) just leaves the
+  // fields editable. No "load once" ref guard here on purpose: under React
+  // StrictMode the mount→unmount→remount cycle would otherwise let the first
+  // (cancelled) run win and discard the result. Each run owns its own
+  // `cancelled` flag, and the load is idempotent.
+  useEffect(() => {
+    if (!isMainnet || !address || !matrixRoomId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        await awaitCompletion();
+        const mxClient = getMatrixClient();
+        if (cancelled || !mxClient) return;
+        // Gate first (cheap, unencrypted index read), then prefill if they qualify.
+        const owns = hasKycCredential(mxClient, matrixRoomId);
+        if (cancelled) return;
+        setHasKyc(owns);
+        // setHasKyc(false);
+        // Remembered fields from a previous withdrawal (editable prefill).
+        const saved = await loadOfframpProfile(mxClient, matrixRoomId);
+        if (!cancelled) setSavedProfile(saved);
+        if (!owns) return;
+        const result = await loadKycPrefill(mxClient, matrixRoomId);
+        if (!cancelled) setPrefill(result);
+      } catch {
+        /* best-effort — leave the gate "checking" if matrix isn't reachable */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [isMainnet, address, matrixRoomId, awaitCompletion, getMatrixClient]);
+
+  // Apply the prefill into the form once it arrives.
+  useEffect(() => {
+    if (!prefill) return;
+    if (prefill.name) setKycName(prefill.name);
+    if (prefill.dob) setKycDob(prefill.dob);
+    if (prefill.country) setKycCountry(prefill.country);
+    if (prefill.idType) setKycIdType(prefill.idType);
+    if (prefill.idNumber) setKycIdNumber(prefill.idNumber);
+    if (prefill.email) setKycEmail(prefill.email);
+    if (prefill.phone) setKycPhone(prefill.phone);
+  }, [prefill]);
+
+  // Apply remembered fields (once) — editable, and only where KYC didn't lock
+  // the field (KYC wins; its apply effect above overwrites + locks regardless of
+  // order). The saved bank is deferred until its country's list loads.
+  useEffect(() => {
+    if (!savedProfile || appliedSavedRef.current) return;
+    appliedSavedRef.current = true;
+    // Payout details — never KYC-locked.
+    if (savedProfile.country) setCountry(savedProfile.country);
+    if (savedProfile.accountNumber) setAccountNumber(savedProfile.accountNumber);
+    if (savedProfile.accountName) setAccountName(savedProfile.accountName);
+    if (savedProfile.networkId) setPendingBankId(savedProfile.networkId);
+    if (savedProfile.bvn) setKycBvn(savedProfile.bvn);
+    // Contact / identity — only when KYC didn't provide (and lock) them.
+    if (savedProfile.name && !prefill?.name) setKycName(savedProfile.name);
+    if (savedProfile.phone && !prefill?.phone) setKycPhone(savedProfile.phone);
+    if (savedProfile.email && !prefill?.email) setKycEmail(savedProfile.email);
+    if (savedProfile.dob && !prefill?.dob) setKycDob(savedProfile.dob);
+    if (savedProfile.nationality && !prefill?.country) setKycCountry(savedProfile.nationality);
+    if (savedProfile.idType && !prefill?.idType) setKycIdType(savedProfile.idType);
+    if (savedProfile.idNumber && !prefill?.idNumber) setKycIdNumber(savedProfile.idNumber);
+  }, [savedProfile, prefill]);
+
+  // Apply the saved bank once its country's channels have loaded and it's still
+  // a valid option (loadBanks resets networkId on country change).
+  useEffect(() => {
+    if (!pendingBankId) return;
+    if (bankNetworks.some((n) => n.id === pendingBankId)) {
+      setNetworkId(pendingBankId);
+      setPendingBankId(null);
+    }
+  }, [pendingBankId, bankNetworks]);
+
+  // Supported payout countries — from the worker (single source of truth).
+  useEffect(() => {
+    let cancelled = false;
+    fetchSupportedCountries()
+      .then((codes) => {
+        if (!cancelled) setSupportedOptions(countryOptions(codes));
+      })
+      .catch(() => {
+        if (!cancelled) setSupportedOptions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const loadBanks = useCallback(async () => {
+    setLoadingBanks(true);
+    setFormError(null);
+    setNetworkId('');
+    setQuote(null);
+    try {
+      const { channels: ch, networks } = await discoverChannels(country);
+      setChannels(ch);
+      setBankNetworks(networks.filter((n) => (n.status ? n.status.toLowerCase() === 'active' : true) && n.name));
+    } catch (err) {
+      setFormError(err instanceof Error ? err.message : 'Failed to load banks');
+    } finally {
+      setLoadingBanks(false);
+    }
+  }, [country]);
+
+  useEffect(() => {
+    if (isMainnet && country) void loadBanks();
+  }, [isMainnet, country, loadBanks]);
+
+  const channelCandidates = useMemo<YcChannel[]>(() => {
+    if (!networkId) return [];
+    const net = bankNetworks.find((n) => n.id === networkId);
+    if (!net) return [];
+    const ids = new Set(networkChannelIds(net));
+    return channels.filter(
+      (c) =>
+        ids.has(c.id) &&
+        (c.status ? c.status.toLowerCase() === 'active' : true) &&
+        (c.rampType ? c.rampType.toLowerCase() === 'withdraw' : true),
+    );
+  }, [networkId, bankNetworks, channels]);
+
+  const currency = useMemo(() => channelCandidates.find((c) => c.currency)?.currency ?? '', [channelCandidates]);
+  const channelType = useMemo(
+    () => (channelCandidates.some((c) => (c.channelType ?? '').toLowerCase() === 'momo') ? 'momo' : 'bank'),
+    [channelCandidates],
+  );
+  const settlementSecs = useMemo(
+    () => channelCandidates.find((c) => c.estimatedSettlementTime)?.estimatedSettlementTime,
+    [channelCandidates],
+  );
+  const selectedBankName = useMemo(
+    () => bankNetworks.find((n) => n.id === networkId)?.name ?? '',
+    [bankNetworks, networkId],
+  );
+
+  // The quote is only valid for the exact amount + channel it was taken for.
+  const clearOfframpError = offramp.clearError;
+  useEffect(() => {
+    setQuote(null);
+    setFormError(null);
+    clearOfframpError();
+  }, [amount, currency, channelType, clearOfframpError]);
+
+  // Once an attempt is created, clear the amount and expand the new row.
+  const activeId = offramp.active?.id;
+  useEffect(() => {
+    if (activeId) {
+      setAmount('');
+      setExpandedTxId(activeId);
+    }
+  }, [activeId]);
+
+  const transactions = offramp.transactions;
+  const hasInflightTx = transactions.some((t) => !TERMINAL_OFFRAMP_STATUSES.has(t.status));
+  const refreshTransactions = offramp.refreshTransactions;
+
+  // Load history once on mount.
+  const didInitialLoadRef = useRef(false);
+  useEffect(() => {
+    if (didInitialLoadRef.current) return;
+    if (isMainnet && address) {
+      didInitialLoadRef.current = true;
+      void refreshTransactions().catch(() => undefined);
+    }
+  }, [isMainnet, address, refreshTransactions]);
+
+  // Poll the list every 10s while anything is in-flight.
+  useEffect(() => {
+    if (!hasInflightTx) return;
+    const interval = setInterval(() => void refreshTransactions().catch(() => undefined), 10000);
+    return () => clearInterval(interval);
+  }, [hasInflightTx, refreshTransactions]);
+
+  // Live Skip bridge state for the expanded row.
+  useEffect(() => {
+    if (!expandedTxId) return;
+    const tx = transactions.find((t) => t.id === expandedTxId);
+    if (!tx?.skip_tx_hash) return;
+    let cancelled = false;
+    getSkipStatus(IXO_CHAIN_ID, tx.skip_tx_hash)
+      .then((s) => {
+        if (!cancelled) setSkipStatuses((prev) => ({ ...prev, [tx.id]: s.state }));
+      })
+      .catch(() => {
+        if (!cancelled) setSkipStatuses((prev) => ({ ...prev, [tx.id]: 'unknown' }));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [expandedTxId, transactions]);
+
+  const amountNum = parseFloat(amount);
+  const showForm = Number.isFinite(amountNum) && amountNum > 0;
+  const overBalance = Number.isFinite(amountNum) && balance != null && amountNum > balance;
+
+  const fiatOut = quote?.fiatReceived != null ? Number(quote.fiatReceived) : null;
+  const candidateMins = channelCandidates.map((c) => c.min).filter((n): n is number => typeof n === 'number');
+  const candidateMaxs = channelCandidates.map((c) => c.max).filter((n): n is number => typeof n === 'number');
+  const aggMin = candidateMins.length ? Math.min(...candidateMins) : null;
+  const aggMax = candidateMaxs.length ? Math.max(...candidateMaxs) : null;
+  const limitMin = quote?.transactionLimitMin ?? aggMin;
+  const limitMax = quote?.transactionLimitMax ?? aggMax;
+  const belowMin = !!quote && fiatOut != null && limitMin != null && fiatOut < limitMin;
+  const aboveMax = !!quote && fiatOut != null && limitMax != null && fiatOut > limitMax;
+
+  const nameValid = kycName.trim().split(/\s+/).filter(Boolean).length >= 2;
+  const emailValid = EMAIL_RE.test(kycEmail);
+  const phoneDigits = kycPhone.replace(/\D/g, '');
+  const phoneValid = phoneDigits.length >= 7;
+
+  const canQuote = !!currency && !!channelType && Number.isFinite(amountNum) && amountNum > 0 && !overBalance;
+  const canWithdraw =
+    canQuote &&
+    !!quote &&
+    !belowMin &&
+    !aboveMax &&
+    !!accountNumber &&
+    !!accountName &&
+    nameValid &&
+    emailValid &&
+    phoneValid &&
+    !!kycDob &&
+    !!kycCountry &&
+    !!kycIdNumber &&
+    (!isNG || !!kycBvn);
+
+  const busy = offramp.stage !== 'idle' && offramp.stage !== 'submitted' && offramp.stage !== 'error';
+
+  // A field is locked (read-only) when it came from the user's verified identity.
+  const locked = {
+    name: !!prefill?.name,
+    dob: !!prefill?.dob,
+    country: !!prefill?.country,
+    idType: !!prefill?.idType,
+    idNumber: !!prefill?.idNumber,
+    email: !!prefill?.email,
+    phone: !!prefill?.phone,
+  };
+  const hasPrefill = Object.values(locked).some(Boolean);
+
+  // Remember the fields the user typed so the next visit can pre-fill them
+  // (editable). KYC-locked identity is skipped — it's re-derived from the
+  // credential each time. Best-effort: never blocks the flow.
+  const persistProfile = useCallback(() => {
+    if (!matrixRoomId) return;
+    const mxClient = getMatrixClient();
+    if (!mxClient) return;
+    void saveOfframpProfile(mxClient, matrixRoomId, {
+      country,
+      networkId,
+      bankName: selectedBankName,
+      accountNumber,
+      accountName,
+      name: prefill?.name ? undefined : kycName,
+      phone: prefill?.phone ? undefined : kycPhone,
+      email: prefill?.email ? undefined : kycEmail,
+      dob: prefill?.dob ? undefined : kycDob,
+      nationality: prefill?.country ? undefined : kycCountry,
+      idType: prefill?.idType ? undefined : kycIdType,
+      idNumber: prefill?.idNumber ? undefined : kycIdNumber,
+      bvn: kycBvn,
+    });
+  }, [
+    matrixRoomId,
+    getMatrixClient,
+    country,
+    networkId,
+    selectedBankName,
+    accountNumber,
+    accountName,
+    prefill,
+    kycName,
+    kycPhone,
+    kycEmail,
+    kycDob,
+    kycCountry,
+    kycIdType,
+    kycIdNumber,
+    kycBvn,
+  ]);
+
+  const onQuote = useCallback(async () => {
+    if (!canQuote) return;
+    setQuoting(true);
+    setFormError(null);
+    offramp.clearError();
+    try {
+      const preview = await offramp.previewWithdrawal({
+        amountUsdc: amountNum,
+        currency,
+        channelType,
+        country,
+        sourceDenom: heldDenom,
+      });
+      setQuote(preview.quote);
+      persistProfile();
+    } catch (err) {
+      setQuote(null);
+      setFormError(err instanceof Error ? err.message : 'Quote failed');
+    } finally {
+      setQuoting(false);
+    }
+  }, [canQuote, offramp, amountNum, currency, channelType, country, heldDenom, persistProfile]);
+
+  const onWithdraw = useCallback(async () => {
+    if (!canWithdraw) return;
+    setFormError(null);
+    try {
+      await offramp.withdraw({
+        amountUsdc: amountNum,
+        currency,
+        channelType,
+        sourceDenom: heldDenom,
+        customer: {
+          name: kycName,
+          country: kycCountry,
+          phone: `+${phoneDigits}`,
+          email: kycEmail,
+          dob: formatDob(kycDob),
+          idType: isNG ? 'NIN' : kycIdType,
+          idNumber: kycIdNumber,
+          additionalIdNumber: isNG ? kycBvn : '',
+        },
+        destination: {
+          accountName,
+          accountNumber,
+          accountType: 'bank',
+          networkId: networkId || '',
+          country,
+          bankName: selectedBankName,
+        },
+      });
+      persistProfile();
+    } catch {
+      /* surfaced via offramp.error */
+    }
+  }, [
+    canWithdraw,
+    offramp,
+    amountNum,
+    currency,
+    channelType,
+    heldDenom,
+    kycName,
+    country,
+    phoneDigits,
+    kycEmail,
+    kycDob,
+    kycCountry,
+    isNG,
+    kycIdType,
+    kycIdNumber,
+    kycBvn,
+    accountName,
+    accountNumber,
+    networkId,
+    selectedBankName,
+    persistProfile,
+  ]);
+
+  const onRetry = useCallback(
+    async (tx: OfframpTransaction) => {
+      setRetryingId(tx.id);
+      try {
+        await offramp.retryBridge(tx, heldDenom);
+      } catch {
+        /* surfaced via offramp.error */
+      } finally {
+        setRetryingId(null);
+      }
+    },
+    [offramp, heldDenom],
+  );
+
+  const onDownloadRecord = useCallback(
+    async (tx: OfframpTransaction) => {
+      setDownloadingRecordId(tx.id);
+      try {
+        const blob = await offramp.downloadPaymentRecord(tx.id);
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement('a');
+        a.href = url;
+        a.download = `payment-record-${tx.yc_payment_id ?? tx.id}.pdf`;
+        a.click();
+        URL.revokeObjectURL(url);
+      } catch (err) {
+        setFormError(err instanceof Error ? err.message : 'Could not download the payment record');
+      } finally {
+        setDownloadingRecordId(null);
+      }
+    },
+    [offramp],
+  );
+
+  return (
+    <div className={styles.page}>
+      <Header onGradient title='Withdraw' onBack={() => router.push('/profile')} />
+
+      {/* Green gradient band behind the (fixed) header so its onGradient styles apply. */}
+      <div className={styles.headerBand} />
+
+      <main className={styles.body}>
+        {!isMainnet && <div className={styles.alertInfo}>Withdrawals aren’t available on this network.</div>}
+
+        {isMainnet && (
+          <>
+            {/* Balance */}
+            <div className={styles.card}>
+              {balance == null ? (
+                <div className={styles.balanceRow}>
+                  <span className={styles.balanceUnit}>
+                    {address ? 'Loading USDC balance…' : 'Sign in to see your USDC balance.'}
+                  </span>
+                  {balanceLoading && <Loader size={16} />}
+                </div>
+              ) : (
+                <div className={styles.balanceRow}>
+                  <span className={styles.balanceAmount}>{formatUsdc(balance)}</span>
+                  <span className={styles.balanceUnit}>USDC</span>
+                  {balanceLoading && <Loader size={16} />}
+                </div>
+              )}
+            </div>
+
+            {kycGate === null && (
+              <div className={styles.card}>
+                <div className={styles.balanceRow}>
+                  <Loader size={16} />
+                  <span className={styles.balanceUnit}>Checking your verification…</span>
+                </div>
+              </div>
+            )}
+
+            {kycGate === false && (
+              <div className={styles.card}>
+                <p className={styles.cardTitle}>Verify your identity first</p>
+                <p className={styles.kycGateText}>
+                  You need to complete identity verification (KYC) before you can withdraw. Check your verification
+                  status on your profile.
+                </p>
+                <div className={styles.actions}>
+                  <Button
+                    label='View verification status'
+                    size={BUTTON_SIZE.mediumLarge}
+                    bgColor={BUTTON_BG_COLOR.primary}
+                    borderColor={BUTTON_BORDER_COLOR.primary}
+                    color={BUTTON_COLOR.white}
+                    onClick={() => router.push('/profile')}
+                  />
+                </div>
+              </div>
+            )}
+
+            {kycGate === true && (
+              <>
+                {/* Withdraw form */}
+                <div className={styles.card}>
+                  <p className={styles.cardTitle}>Withdraw USDC</p>
+
+                  <div className={styles.row}>
+                    <div className={styles.field}>
+                      <label className={styles.label}>Amount (USDC)</label>
+                      <input
+                        className={`${styles.input}${overBalance ? ` ${styles.inputError}` : ''}`}
+                        type='number'
+                        inputMode='decimal'
+                        min={0}
+                        placeholder='0.00'
+                        value={amount}
+                        onChange={(e) => setAmount(e.currentTarget.value)}
+                      />
+                      {overBalance && <span className={styles.errorText}>Exceeds your available USDC</span>}
+                    </div>
+                    <div className={styles.field}>
+                      <label className={styles.label}>Country</label>
+                      <select
+                        className={styles.select}
+                        value={country}
+                        onChange={(e) => setCountry(e.currentTarget.value)}
+                      >
+                        {supportedOptions.map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+
+                  <div className={`${styles.collapse}${showForm ? ` ${styles.collapseOpen}` : ''}`}>
+                    <div className={styles.collapseInner}>
+                      <div className={styles.row}>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Bank</label>
+                          <select
+                            className={styles.select}
+                            value={networkId}
+                            disabled={loadingBanks || bankNetworks.length === 0}
+                            onChange={(e) => {
+                              setNetworkId(e.currentTarget.value);
+                              setQuote(null);
+                            }}
+                          >
+                            <option value=''>
+                              {loadingBanks
+                                ? 'Loading banks…'
+                                : bankNetworks.length
+                                ? 'Select your bank'
+                                : 'No banks for this country'}
+                            </option>
+                            {bankNetworks.map((n) => (
+                              <option key={n.id} value={n.id}>
+                                {n.code ? `${n.name} (${n.code})` : n.name ?? n.id}
+                              </option>
+                            ))}
+                          </select>
+                          {currency && (limitMin != null || limitMax != null) && (
+                            <span className={styles.hint}>
+                              Limits {limitMin ?? '?'}–{limitMax ?? '?'} {currency}
+                              {settlementSecs ? ` · ~${settlementSecs}s settlement` : ''}
+                            </span>
+                          )}
+                        </div>
+                        {currency && (
+                          <div className={styles.field}>
+                            <label className={styles.label}>Paid out in</label>
+                            <input className={styles.input} value={currency} readOnly />
+                            <span className={styles.hint}>Currency this bank receives</span>
+                          </div>
+                        )}
+                      </div>
+
+                      {networkId && channelCandidates.length === 0 && (
+                        <span className={styles.warnLine}>No active withdraw channel for this bank.</span>
+                      )}
+
+                      <div className={styles.row}>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Bank account number</label>
+                          <input
+                            className={styles.input}
+                            value={accountNumber}
+                            onChange={(e) => setAccountNumber(e.currentTarget.value)}
+                          />
+                        </div>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Account holder name</label>
+                          <input
+                            className={styles.input}
+                            value={accountName}
+                            onChange={(e) => setAccountName(e.currentTarget.value)}
+                          />
+                          {/* <span className={styles.hint}>Name on the bank account (YC verifies this)</span> */}
+                        </div>
+                      </div>
+
+                      <div className={styles.divider}>
+                        <span className={styles.dividerLabel}>
+                          Your details (KYC){hasPrefill && <InfoIcon label={KYC_INFO_LABEL} />}
+                        </span>
+                      </div>
+
+                      <div className={styles.row}>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Full name{locked.name && <PrefilledMark />}</label>
+                          <input
+                            className={`${styles.input}${kycName && !nameValid ? ` ${styles.inputError}` : ''}`}
+                            placeholder='First Last'
+                            value={kycName}
+                            readOnly={locked.name}
+                            onChange={(e) => setKycName(e.currentTarget.value)}
+                          />
+                          {kycName && !nameValid && <span className={styles.errorText}>Enter first and last name</span>}
+                        </div>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Email{locked.email && <PrefilledMark />}</label>
+                          <input
+                            className={`${styles.input}${kycEmail && !emailValid ? ` ${styles.inputError}` : ''}`}
+                            type='email'
+                            value={kycEmail}
+                            readOnly={locked.email}
+                            onChange={(e) => setKycEmail(e.currentTarget.value)}
+                          />
+                          {kycEmail && !emailValid && <span className={styles.errorText}>Invalid email</span>}
+                        </div>
+                      </div>
+
+                      <div className={styles.row}>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Phone{locked.phone && <PrefilledMark />}</label>
+                          <div
+                            className={`${styles.inputPrefixWrap}${
+                              kycPhone && !phoneValid ? ` ${styles.inputError}` : ''
+                            }${locked.phone ? ` ${styles.lockedWrap}` : ''}`}
+                          >
+                            <span className={styles.inputPrefix}>+</span>
+                            <input
+                              className={styles.bareInput}
+                              inputMode='numeric'
+                              placeholder='27821234567'
+                              value={kycPhone}
+                              readOnly={locked.phone}
+                              onChange={(e) => setKycPhone(e.currentTarget.value.replace(/[^\d]/g, ''))}
+                            />
+                          </div>
+                          {kycPhone && !phoneValid && (
+                            <span className={styles.errorText}>Enter full international number</span>
+                          )}
+                        </div>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Date of birth{locked.dob && <PrefilledMark />}</label>
+                          <input
+                            className={styles.input}
+                            type='date'
+                            max={new Date().toISOString().slice(0, 10)}
+                            value={kycDob}
+                            readOnly={locked.dob}
+                            onChange={(e) => setKycDob(e.currentTarget.value)}
+                          />
+                        </div>
+                      </div>
+
+                      <div className={styles.row}>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Your country{locked.country && <PrefilledMark />}</label>
+                          <select
+                            className={styles.select}
+                            value={kycCountry}
+                            disabled={locked.country}
+                            onChange={(e) => setKycCountry(e.currentTarget.value)}
+                          >
+                            {ALL_COUNTRY_OPTIONS.map((o) => (
+                              <option key={o.value} value={o.value}>
+                                {o.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className={styles.field}>
+                          <label className={styles.label}>ID type{!isNG && locked.idType && <PrefilledMark />}</label>
+                          {isNG ? (
+                            <input className={styles.input} value='NIN' readOnly />
+                          ) : (
+                            <select
+                              className={styles.select}
+                              value={kycIdType}
+                              disabled={locked.idType}
+                              onChange={(e) => setKycIdType(e.currentTarget.value)}
+                            >
+                              {ID_TYPE_OPTIONS.map((o) => (
+                                <option key={o.value} value={o.value}>
+                                  {o.label}
+                                </option>
+                              ))}
+                            </select>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className={styles.row}>
+                        <div className={styles.field}>
+                          <label className={styles.label}>
+                            {isNG ? 'NIN' : 'ID number'}
+                            {locked.idNumber && <PrefilledMark />}
+                          </label>
+                          <input
+                            className={styles.input}
+                            value={kycIdNumber}
+                            readOnly={locked.idNumber}
+                            onChange={(e) => setKycIdNumber(e.currentTarget.value)}
+                          />
+                        </div>
+                        {isNG && (
+                          <div className={styles.field}>
+                            <label className={styles.label}>BVN</label>
+                            <input
+                              className={styles.input}
+                              value={kycBvn}
+                              onChange={(e) => setKycBvn(e.currentTarget.value)}
+                            />
+                            {/* <span className={styles.hint}>Required for Nigeria</span> */}
+                          </div>
+                        )}
+                      </div>
+
+                      {quote && (
+                        <div className={`${styles.quote}${belowMin || aboveMax ? ` ${styles.quoteWarn}` : ''}`}>
+                          <span className={styles.quoteMain}>
+                            You receive ~{quote.fiatReceived ?? '?'} {currency}
+                            <InfoIcon label={ESTIMATE_NOTE} />
+                          </span>
+                          {belowMin && limitMin != null && (
+                            <span className={styles.warnLine}>
+                              Below the {limitMin} {currency} minimum — increase the amount.
+                            </span>
+                          )}
+                          {aboveMax && limitMax != null && (
+                            <span className={styles.warnLine}>
+                              Above the {limitMax} {currency} maximum — reduce the amount.
+                            </span>
+                          )}
+                        </div>
+                      )}
+
+                      {/* {did && <span className={styles.hint}>Linked to your DID for tracking.</span>} */}
+
+                      <div className={styles.actions}>
+                        {quote ? (
+                          <Button
+                            label={busy ? 'Withdrawing…' : 'Withdraw'}
+                            size={BUTTON_SIZE.mediumLarge}
+                            bgColor={BUTTON_BG_COLOR.primary}
+                            borderColor={BUTTON_BORDER_COLOR.primary}
+                            color={BUTTON_COLOR.white}
+                            disabled={!canWithdraw || busy}
+                            onClick={onWithdraw}
+                          />
+                        ) : (
+                          <Button
+                            label={quoting ? 'Getting quote…' : 'Get quote'}
+                            size={BUTTON_SIZE.mediumLarge}
+                            bgColor={BUTTON_BG_COLOR.primary}
+                            borderColor={BUTTON_BORDER_COLOR.primary}
+                            color={BUTTON_COLOR.white}
+                            disabled={!canQuote || quoting}
+                            onClick={onQuote}
+                          />
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  {(formError || offramp.error) && (
+                    <div className={styles.alertError}>{formError || offramp.error}</div>
+                  )}
+                </div>
+
+                {/* History — only shown once there's at least one withdrawal */}
+                {transactions.length > 0 && (
+                  <div className={styles.card}>
+                    <div className={styles.historyHeader}>
+                      <p className={styles.cardTitle} style={{ margin: 0 }}>
+                        Your withdrawals
+                      </p>
+                      <button
+                        type='button'
+                        className={styles.iconButton}
+                        aria-label='Refresh withdrawals'
+                        onClick={() => void refreshTransactions().catch(() => undefined)}
+                      >
+                        <svg
+                          width={16}
+                          height={16}
+                          viewBox='0 0 24 24'
+                          fill='none'
+                          stroke='currentColor'
+                          strokeWidth='2'
+                          strokeLinecap='round'
+                          strokeLinejoin='round'
+                        >
+                          <polyline points='23 4 23 10 17 10' />
+                          <polyline points='1 20 1 14 7 14' />
+                          <path d='M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15' />
+                        </svg>
+                      </button>
+                    </div>
+
+                    {transactions.map((tx) => {
+                      const expanded = expandedTxId === tx.id;
+                      const sent = tx.send_amount_usdc ?? tx.amount_usd;
+                      const txYcFee = (tx.service_fee_usd ?? 0) + (tx.partner_fee_usd ?? 0);
+                      const bridging = tx.status === 'created' && !!tx.skip_tx_hash;
+                      const isTerminal = TERMINAL_OFFRAMP_STATUSES.has(tx.status);
+                      const good = tx.status === 'completed' || tx.status === 'refunded';
+                      const dest = (tx.destination ?? {}) as {
+                        accountName?: string;
+                        accountNumber?: string;
+                        bankName?: string;
+                      };
+                      const statusClass = bridging
+                        ? styles.statusBlue
+                        : isTerminal
+                        ? good
+                          ? styles.statusGreen
+                          : styles.statusRed
+                        : styles.statusBlue;
+                      const statusLabel = bridging ? 'bridging' : tx.status.replace(/_/g, ' ');
+                      const inProgress = (offramp.active?.id === tx.id && busy) || retryingId === tx.id;
+                      const skipFailed = /ERROR|FAIL|ABANDON/i.test(skipStatuses[tx.id] ?? '');
+                      const bridgeIncomplete = !tx.skip_tx_hash || skipFailed;
+                      const withinWindow = tx.expires_at != null && tx.expires_at * 1000 - Date.now() > 90_000;
+                      const canComplete = !isTerminal && bridgeIncomplete && withinWindow && !inProgress;
+                      return (
+                        <div key={tx.id} className={styles.txCard}>
+                          <button className={styles.txHead} onClick={() => setExpandedTxId(expanded ? null : tx.id)}>
+                            <span>
+                              <span className={styles.txTitle}>
+                                {sent ?? '?'} USDC → {tx.local_amount ?? '?'} {tx.local_currency ?? ''}
+                              </span>
+                              <br />
+                              <span className={styles.txSub}>
+                                {new Date(tx.created_at * 1000).toLocaleString()} · {tx.crypto_network}
+                              </span>
+                            </span>
+                            <span className={`${styles.txStatus} ${statusClass}`}>{statusLabel}</span>
+                          </button>
+
+                          {canComplete && (
+                            <div className={styles.completeBar}>
+                              <span className={styles.warnLine}>
+                                Transfer didn’t complete — finish before it expires.
+                              </span>
+                              <Button
+                                label={retryingId === tx.id ? 'Completing…' : 'Complete'}
+                                size={BUTTON_SIZE.small}
+                                bgColor={BUTTON_BG_COLOR.primary}
+                                borderColor={BUTTON_BORDER_COLOR.primary}
+                                color={BUTTON_COLOR.white}
+                                disabled={retryingId === tx.id}
+                                onClick={() => onRetry(tx)}
+                              />
+                            </div>
+                          )}
+
+                          {expanded && (
+                            <div className={styles.txDetail}>
+                              <div className={styles.detailRow}>
+                                <span>Sent from ixo</span>
+                                <span className={styles.detailVal}>{sent ?? '?'} USDC</span>
+                              </div>
+                              {tx.skip_fee_usd != null && (
+                                <div className={styles.detailRow}>
+                                  <span>Bridge fee (Skip)</span>
+                                  <span className={styles.detailVal}>~${tx.skip_fee_usd.toFixed(2)}</span>
+                                </div>
+                              )}
+                              <div className={styles.detailRow}>
+                                <span>Reached YellowCard</span>
+                                <span className={styles.detailVal}>{tx.amount_usd ?? '?'} USDC</span>
+                              </div>
+                              <div className={styles.detailRow}>
+                                <span>YellowCard fee</span>
+                                <span className={styles.detailVal}>~${txYcFee.toFixed(2)}</span>
+                              </div>
+                              <div className={styles.detailRow}>
+                                <span>You receive</span>
+                                <span className={styles.detailVal} style={{ fontWeight: 600 }}>
+                                  {tx.local_amount ?? '?'} {tx.local_currency ?? ''}
+                                </span>
+                              </div>
+                              {tx.rate != null && (
+                                <div className={styles.detailRow}>
+                                  <span>Rate</span>
+                                  <span className={styles.detailVal}>
+                                    1 USDC ≈ {tx.rate} {tx.local_currency ?? ''}
+                                  </span>
+                                </div>
+                              )}
+                              <div className={styles.detailRow}>
+                                <span>YellowCard status</span>
+                                <span className={styles.detailVal} style={{ textTransform: 'capitalize' }}>
+                                  {tx.status.replace(/_/g, ' ')}
+                                </span>
+                              </div>
+                              {tx.skip_tx_hash && (
+                                <div className={styles.detailRow}>
+                                  <span>Bridge (Skip)</span>
+                                  <span className={`${styles.detailVal}${skipFailed ? ` ${styles.statusRed}` : ''}`}>
+                                    {(skipStatuses[tx.id] ?? 'checking…')
+                                      .replace(/^STATE_/, '')
+                                      .replace(/_/g, ' ')
+                                      .toLowerCase()}
+                                  </span>
+                                </div>
+                              )}
+                              {tx.error && (
+                                <span className={styles.errorText}>Error: {tx.error_detail ?? tx.error}</span>
+                              )}
+
+                              <div className={styles.divider}>Sent to</div>
+                              {dest.accountName && (
+                                <div className={styles.detailRow}>
+                                  <span>Account holder</span>
+                                  <span className={styles.detailVal}>{dest.accountName}</span>
+                                </div>
+                              )}
+                              {dest.accountNumber && (
+                                <div className={styles.detailRow}>
+                                  <span>Account number</span>
+                                  <span className={styles.detailVal}>{dest.accountNumber}</span>
+                                </div>
+                              )}
+                              {dest.bankName && (
+                                <div className={styles.detailRow}>
+                                  <span>Bank</span>
+                                  <span className={styles.detailVal}>{dest.bankName}</span>
+                                </div>
+                              )}
+                              {tx.yc_payment_id && (
+                                <div className={styles.detailRow}>
+                                  <span>YellowCard payment ID</span>
+                                  <span className={styles.detailVal} style={{ fontFamily: 'monospace' }}>
+                                    {tx.yc_payment_id}
+                                  </span>
+                                </div>
+                              )}
+
+                              {tx.status === 'completed' && (
+                                <div className={styles.actions}>
+                                  <Button
+                                    label={downloadingRecordId === tx.id ? 'Preparing…' : 'Payment record'}
+                                    size={BUTTON_SIZE.small}
+                                    bgColor={BUTTON_BG_COLOR.grey}
+                                    borderColor={BUTTON_BORDER_COLOR.grey}
+                                    color={BUTTON_COLOR.white}
+                                    disabled={downloadingRecordId === tx.id}
+                                    onClick={() => onDownloadRecord(tx)}
+                                  />
+                                </div>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline info marker — a green "i" / asterisk that reveals a small tooltip on
+// click (tap-friendly) or hover (native title). Closes on blur.
+// ---------------------------------------------------------------------------
+
+function InfoMark({ children, label, markClassName }: { children: ReactNode; label: string; markClassName: string }) {
+  const ref = useRef<HTMLButtonElement>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  // Portal the bubble to <body> with fixed positioning so it escapes the form's
+  // overflow:hidden collapse (which would otherwise clip it). Clamp to viewport.
+  const toggle = () =>
+    setPos((cur) => {
+      if (cur) return null;
+      const r = ref.current?.getBoundingClientRect();
+      if (!r) return null;
+      return { top: r.bottom + 6, left: Math.max(8, Math.min(r.left, window.innerWidth - 232)) };
+    });
+
+  useEffect(() => {
+    if (!pos) return;
+    const close = () => setPos(null);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [pos]);
+
+  return (
+    <>
+      <button
+        ref={ref}
+        type='button'
+        className={markClassName}
+        aria-label={label}
+        title={label}
+        onClick={toggle}
+        onBlur={() => setPos(null)}
+      >
+        {children}
+      </button>
+      {pos &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <span className={styles.infoBubble} style={{ top: pos.top, left: pos.left }} role='tooltip'>
+            {label}
+          </span>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+/** Green asterisk shown in a field label when that field was auto-filled. */
+function PrefilledMark() {
+  return (
+    <InfoMark label={VERIFIED_LABEL} markClassName={styles.asteriskMark}>
+      *
+    </InfoMark>
+  );
+}
+
+/** Green "i" that reveals `label` on click — used by the KYC heading and the
+ *  estimated-payout note. */
+function InfoIcon({ label }: { label: string }) {
+  return (
+    <InfoMark label={label} markClassName={styles.infoMark}>
+      <svg
+        width={14}
+        height={14}
+        viewBox='0 0 24 24'
+        fill='none'
+        stroke='currentColor'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      >
+        <circle cx='12' cy='12' r='10' />
+        <line x1='12' y1='16' x2='12' y2='12' />
+        <line x1='12' y1='8' x2='12.01' y2='8' />
+      </svg>
+    </InfoMark>
+  );
+}

--- a/screens/profile.tsx
+++ b/screens/profile.tsx
@@ -167,6 +167,52 @@ export default function ProfileScreen() {
         </h3>
 
         <KycCredentialsCard />
+
+        <h3
+          style={{
+            margin: '24px 0 8px',
+            fontSize: '1.1rem',
+            fontWeight: 500,
+            color: 'var(--text-primary)',
+          }}
+        >
+          Wallet
+        </h3>
+
+        <button
+          onClick={() => router.push('/profile/offramp')}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            padding: '16px',
+            border: 'none',
+            borderRadius: 'var(--card-border-radius)',
+            background: 'var(--background-color, #fff)',
+            cursor: 'pointer',
+            color: 'var(--text-primary)',
+          }}
+        >
+          <span style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 2 }}>
+            <span style={{ fontWeight: 500 }}>Withdraw</span>
+            <span style={{ fontSize: '0.78rem', color: 'var(--text-secondary)' }}>
+              Cash out your USDC via YellowCard
+            </span>
+          </span>
+          <svg
+            width={20}
+            height={20}
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth='2'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+          >
+            <polyline points='9 18 15 12 9 6' />
+          </svg>
+        </button>
       </main>
     </div>
   );

--- a/styles/Offramp.module.scss
+++ b/styles/Offramp.module.scss
@@ -1,0 +1,423 @@
+.page {
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+// Green gradient band behind the fixed header (matches /settings).
+.headerBand {
+  background: radial-gradient(ellipse at top right, var(--green-secondary), var(--green-primary) 70%);
+  height: var(--header-height);
+}
+
+.body {
+  width: 100%;
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  flex: 1;
+}
+
+.card {
+  background: var(--card-bg-color);
+  border-radius: var(--card-border-radius);
+  padding: 16px;
+}
+
+.cardTitle {
+  margin: 0 0 12px;
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.kycGateText {
+  margin: 0 0 16px;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  color: var(--text-secondary);
+}
+
+.balanceRow {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+}
+
+.balanceAmount {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.balanceUnit {
+  font-size: 0.9rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+// Height + fade collapse for the form body (grid-rows trick animates an
+// auto-sized child smoothly, unlike a plain mount/unmount).
+.collapse {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 240ms ease;
+}
+
+.collapseOpen {
+  grid-template-rows: 1fr;
+}
+
+.collapseInner {
+  overflow: hidden;
+  min-height: 0;
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.collapseOpen .collapseInner {
+  opacity: 1;
+  padding-top: 4px;
+}
+
+.row {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.field {
+  flex: 1;
+  min-width: 140px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-bottom: 12px;
+}
+
+.label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.hint {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+// Inline info marker (green "i" / asterisk) that reveals a small tooltip on
+// click (tap-friendly) or hover (native title); closes on blur.
+.infoMark,
+.asteriskMark {
+  display: inline-flex;
+  align-items: center;
+  vertical-align: middle;
+  margin-left: 4px;
+  padding: 0;
+  border: none;
+  outline: none;
+  background: none;
+  line-height: 1;
+  color: var(--green-primary);
+  cursor: pointer;
+}
+
+.asteriskMark {
+  margin-left: 3px;
+  font-size: 0.95rem;
+  font-weight: 700;
+}
+
+// Portalled to <body>; positioned via inline top/left (fixed) so it can't be
+// clipped by the form's overflow:hidden collapse.
+.infoBubble {
+  position: fixed;
+  z-index: 50;
+  width: max-content;
+  max-width: 220px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  font-size: 0.72rem;
+  font-weight: 400;
+  line-height: 1.3;
+  color: var(--bg-secondary);
+  background: var(--text-primary);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.18);
+}
+
+.dividerLabel {
+  display: inline-flex;
+  align-items: center;
+  white-space: nowrap;
+}
+
+// Greyed wrapper for a locked prefix-input (e.g. the phone field).
+.lockedWrap {
+  background: var(--card-bg-color);
+}
+
+.lockedWrap .bareInput {
+  color: var(--text-secondary);
+}
+
+.input,
+.select {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 10px 12px;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  background: var(--bg-secondary);
+  border: 1px solid var(--input-border-color);
+  border-radius: 10px;
+  outline: none;
+}
+
+.input:focus,
+.select:focus {
+  border-color: var(--green-primary);
+}
+
+// Remove the native number-input spinner arrows.
+.input[type='number']::-webkit-outer-spin-button,
+.input[type='number']::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+.input[type='number'] {
+  -moz-appearance: textfield;
+  appearance: textfield;
+}
+
+// Input with a static leading symbol (e.g. "+" for international phone).
+.inputPrefixWrap {
+  display: flex;
+  align-items: center;
+  background: var(--bg-secondary);
+  border: 1px solid var(--input-border-color);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.inputPrefixWrap:focus-within {
+  border-color: var(--green-primary);
+}
+
+.inputPrefixWrap.inputError {
+  border-color: var(--error-color);
+}
+
+.inputPrefix {
+  padding: 10px 4px 10px 12px;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.inputPrefixWrap .bareInput {
+  flex: 1;
+  min-width: 0;
+  padding: 10px 12px 10px 0;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--text-primary);
+  background: transparent;
+  border: none;
+  outline: none;
+}
+
+.input[readonly],
+.input:disabled,
+.select:disabled {
+  color: var(--text-secondary);
+  // Some browsers grey disabled text via text-fill-color/opacity — pin both so
+  // disabled selects match the read-only inputs exactly.
+  -webkit-text-fill-color: var(--text-secondary);
+  opacity: 1;
+  background: var(--card-bg-color);
+  cursor: default;
+}
+
+.inputError {
+  border-color: var(--error-color);
+}
+
+.errorText {
+  font-size: 0.72rem;
+  color: var(--error-color);
+}
+
+.divider {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 8px 0;
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.divider::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-color);
+}
+
+.quote {
+  background: var(--card-bg-color);
+  border-radius: 12px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.quoteWarn {
+  box-shadow: inset 0 0 0 1px var(--yellow-secondary);
+}
+
+.quoteMain {
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.quoteLine {
+  font-size: 0.78rem;
+  color: var(--text-secondary);
+}
+
+.warnLine {
+  font-size: 0.78rem;
+  color: var(--yellow-secondary);
+}
+
+.alertError {
+  background: var(--card-bg-color);
+  border-radius: var(--card-border-radius);
+  padding: 12px 14px;
+  font-size: 0.82rem;
+  color: var(--error-color);
+}
+
+.alertInfo {
+  background: var(--card-bg-color);
+  border-radius: var(--card-border-radius);
+  padding: 14px 16px;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.historyHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.iconButton {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 32px;
+  height: 32px;
+  border: none;
+  border-radius: 50%;
+  background: var(--card-bg-color);
+  color: var(--text-primary);
+  cursor: pointer;
+}
+
+.iconButton:hover {
+  background: var(--card-bg-hover-color);
+}
+
+.txCard {
+  background: var(--card-bg-color);
+  border-radius: 12px;
+  padding: 12px;
+  margin-bottom: 8px;
+}
+
+.txHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  color: inherit;
+  font: inherit;
+}
+
+.txTitle {
+  font-size: 0.88rem;
+  font-weight: 500;
+  color: var(--text-primary);
+}
+
+.txSub {
+  font-size: 0.72rem;
+  color: var(--text-secondary);
+}
+
+.txStatus {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: capitalize;
+  white-space: nowrap;
+}
+
+.statusBlue {
+  color: var(--blue-secondary);
+}
+.statusGreen {
+  color: var(--green-primary);
+}
+.statusRed {
+  color: var(--error-color);
+}
+
+.txDetail {
+  margin-top: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.detailRow {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  font-size: 0.76rem;
+  color: var(--text-secondary);
+}
+
+.detailVal {
+  color: var(--text-primary);
+  text-align: right;
+  word-break: break-all;
+}
+
+.completeBar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 8px;
+}

--- a/utils/countries.ts
+++ b/utils/countries.ts
@@ -1,0 +1,64 @@
+/**
+ * Minimal country helpers for the off-ramp form. Names are derived at runtime
+ * from ISO 3166-1 alpha-2 codes via `Intl.DisplayNames`, and flag emojis from
+ * regional-indicator symbols — so there's no bundled country dataset.
+ */
+
+// ISO 3166-1 alpha-2 codes (sender KYC can be from any country).
+export const ALPHA2_CODES: string[] = [
+  'AD', 'AE', 'AF', 'AG', 'AI', 'AL', 'AM', 'AO', 'AR', 'AT', 'AU', 'AW', 'AZ',
+  'BA', 'BB', 'BD', 'BE', 'BF', 'BG', 'BH', 'BI', 'BJ', 'BN', 'BO', 'BR', 'BS',
+  'BT', 'BW', 'BY', 'BZ', 'CA', 'CD', 'CF', 'CG', 'CH', 'CI', 'CL', 'CM', 'CN',
+  'CO', 'CR', 'CU', 'CV', 'CY', 'CZ', 'DE', 'DJ', 'DK', 'DM', 'DO', 'DZ', 'EC',
+  'EE', 'EG', 'ER', 'ES', 'ET', 'FI', 'FJ', 'FR', 'GA', 'GB', 'GD', 'GE', 'GH',
+  'GM', 'GN', 'GQ', 'GR', 'GT', 'GW', 'GY', 'HN', 'HR', 'HT', 'HU', 'ID', 'IE',
+  'IL', 'IN', 'IQ', 'IR', 'IS', 'IT', 'JM', 'JO', 'JP', 'KE', 'KG', 'KH', 'KM',
+  'KN', 'KR', 'KW', 'KZ', 'LA', 'LB', 'LC', 'LI', 'LK', 'LR', 'LS', 'LT', 'LU',
+  'LV', 'LY', 'MA', 'MC', 'MD', 'ME', 'MG', 'MK', 'ML', 'MM', 'MN', 'MR', 'MT',
+  'MU', 'MV', 'MW', 'MX', 'MY', 'MZ', 'NA', 'NE', 'NG', 'NI', 'NL', 'NO', 'NP',
+  'NZ', 'OM', 'PA', 'PE', 'PG', 'PH', 'PK', 'PL', 'PT', 'PY', 'QA', 'RO', 'RS',
+  'RU', 'RW', 'SA', 'SB', 'SC', 'SD', 'SE', 'SG', 'SI', 'SK', 'SL', 'SN', 'SO',
+  'SR', 'SS', 'ST', 'SV', 'SY', 'SZ', 'TD', 'TG', 'TH', 'TJ', 'TL', 'TM', 'TN',
+  'TO', 'TR', 'TT', 'TW', 'TZ', 'UA', 'UG', 'US', 'UY', 'UZ', 'VC', 'VE', 'VN',
+  'VU', 'WS', 'YE', 'ZA', 'ZM', 'ZW',
+];
+
+let displayNames: Intl.DisplayNames | null = null;
+function regionNames(): Intl.DisplayNames | null {
+  if (displayNames) return displayNames;
+  try {
+    displayNames = new Intl.DisplayNames(['en'], { type: 'region' });
+  } catch {
+    displayNames = null;
+  }
+  return displayNames;
+}
+
+export function countryName(code: string): string {
+  const upper = code.toUpperCase();
+  return regionNames()?.of(upper) ?? upper;
+}
+
+export function flagEmoji(code: string): string {
+  const upper = code.toUpperCase();
+  if (!/^[A-Z]{2}$/.test(upper)) return '';
+  return String.fromCodePoint(...[...upper].map((c) => 0x1f1e6 + c.charCodeAt(0) - 65));
+}
+
+export function countryLabel(code: string): string {
+  const flag = flagEmoji(code);
+  return `${flag ? `${flag} ` : ''}${countryName(code)}`;
+}
+
+export interface CountryOption {
+  value: string;
+  label: string;
+}
+
+export function countryOptions(codes: string[]): CountryOption[] {
+  return codes
+    .map((c) => ({ value: c.toUpperCase(), label: countryLabel(c) }))
+    .sort((a, b) => a.label.localeCompare(b.label));
+}
+
+export const ALL_COUNTRY_OPTIONS: CountryOption[] = countryOptions(ALPHA2_CODES);

--- a/utils/kycPrefill.ts
+++ b/utils/kycPrefill.ts
@@ -1,0 +1,228 @@
+import { findKycLevel1IndexEntry, loadKycLevel1Credential, loadKycPii } from '@utils/approvePayment';
+
+// Reuse the matrix client type the credential loaders already expect, rather
+// than re-importing it from matrix-js-sdk (whose named type export doesn't
+// resolve cleanly in this project).
+type MxClient = Parameters<typeof loadKycLevel1Credential>[0];
+
+/**
+ * Whether the user holds a KYCAMLLevel1 credential in their matrix store. This
+ * reads the unencrypted credential index (no decryption needed), so it's a
+ * reliable "do they have KYC" gate even when the credential body can't be
+ * decrypted on this device.
+ */
+export function hasKycCredential(mxClient: MxClient, roomId: string): boolean {
+  return !!findKycLevel1IndexEntry(mxClient, roomId);
+}
+
+/**
+ * Best-effort auto-fill for the off-ramp KYC form from the user's stored identity.
+ *
+ * Design: each SOURCE declares its own `fields` map — exactly which keys (or a
+ * custom extractor) yield each form field FROM THAT SOURCE. Sources are listed
+ * in priority order; every field independently waterfalls down them — the first
+ * source that yields a value wins. Adding a new source later is one `KYC_SOURCES`
+ * entry with its own `fields` map; nothing else changes.
+ *
+ * Output normalization (date/country/id-type/phone formats) is global per field
+ * — it's about the form's expected shape, not the source — and applied after a
+ * source's raw value is extracted.
+ *
+ * Current sources, both already saved in the user's encrypted matrix room:
+ *  - the KYCAMLLevel1 verifiable credential — authoritative identity (name, DOB,
+ *    nationality, document type). Claims are an SD-JWT-style map `{ key: { value } }`.
+ *  - the raw KYC PII blob — flat form data with fields the credential omits /
+ *    selectively discloses (document number, email, …).
+ *
+ * Any field we resolve is treated as verified and locked in the form; anything
+ * we can't resolve is left for the user to fill in.
+ */
+export interface KycPrefill {
+  /** Full legal name (given + family). */
+  name?: string;
+  /** YYYY-MM-DD (the <input type="date"> format). */
+  dob?: string;
+  /** Sender nationality, ISO alpha-2. */
+  country?: string;
+  /** Mapped to the form's options: passport | national_id | drivers_license. */
+  idType?: string;
+  /** Identity document number. */
+  idNumber?: string;
+  email?: string;
+  /** Digits only, no leading '+'. */
+  phone?: string;
+}
+
+type FieldKey = keyof KycPrefill;
+
+/** How a source yields one field: a list of candidate keys, or a custom reader. */
+type Extractor = string[] | ((record: Record<string, any>) => unknown);
+
+export interface KycSource {
+  name: string;
+  /** Return the source's raw record, or null when absent / unreadable. Must be
+   *  best-effort: never throw (a missing source must not block the others). */
+  load: (mxClient: MxClient, roomId: string) => Promise<Record<string, any> | null>;
+  /** Per-source field mapping. Omit a field this source doesn't carry. */
+  fields: Partial<Record<FieldKey, Extractor>>;
+}
+
+const ok = (v: unknown) => v !== undefined && v !== null && String(v).trim() !== '';
+
+function snakeToCamel(key: string): string {
+  return key.replace(/_([a-z])/g, (_, c) => c.toUpperCase());
+}
+
+/** Read a field from one source — a credential's `claims` map ({ value }) or a
+ *  flat object — trying each candidate key, also as camelCase. */
+function readKeys(source: Record<string, any>, keys: string[]): unknown {
+  for (const key of keys) {
+    const nested = source.claims?.[key];
+    if (nested && typeof nested === 'object' && 'value' in nested) {
+      if (ok(nested.value)) return nested.value;
+    } else if (ok(nested)) {
+      return nested;
+    }
+    if (ok(source[key])) return source[key];
+    const camel = snakeToCamel(key);
+    if (ok(source[camel])) return source[camel];
+  }
+  return undefined;
+}
+
+function extract(source: Record<string, any>, def: Extractor): unknown {
+  return typeof def === 'function' ? def(source) : readKeys(source, def);
+}
+
+/** Compose a full name from given + family (each tried across `keys`), falling
+ *  back to a single full-name field. Used as a custom extractor per source. */
+function composeName(givenKeys: string[], familyKeys: string[], fullKeys: string[] = []) {
+  return (record: Record<string, any>): string | undefined => {
+    const given = readKeys(record, givenKeys);
+    const family = readKeys(record, familyKeys);
+    const composed = [given, family].filter(ok).map(String).join(' ').trim();
+    if (composed) return composed;
+    return fullKeys.length ? (readKeys(record, fullKeys) as string | undefined) : undefined;
+  };
+}
+
+// --- Output normalizers (global per field; applied after extraction) ---
+
+const DOC_TYPE_MAP: Record<string, string> = {
+  passport: 'passport',
+  national_identity_card: 'national_id',
+  national_id: 'national_id',
+  national_identity_number: 'national_id',
+  id_card: 'national_id',
+  identity_card: 'national_id',
+  drivers_license: 'drivers_license',
+  driver_license: 'drivers_license',
+  driving_license: 'drivers_license',
+  driving_licence: 'drivers_license',
+};
+
+function mapIdType(raw: string): string | undefined {
+  return DOC_TYPE_MAP[raw.toLowerCase().replace(/[\s-]+/g, '_')];
+}
+
+function normCountry(raw: string): string | undefined {
+  const c = raw.trim().toUpperCase();
+  return /^[A-Z]{2}$/.test(c) ? c : undefined;
+}
+
+function normDob(raw: string): string | undefined {
+  const s = raw.trim();
+  let m = /^(\d{4})-(\d{2})-(\d{2})/.exec(s);
+  if (m) return `${m[1]}-${m[2]}-${m[3]}`;
+  m = /^(\d{2})\/(\d{2})\/(\d{4})$/.exec(s); // MM/DD/YYYY
+  if (m) return `${m[3]}-${m[1]}-${m[2]}`;
+  const d = new Date(s);
+  if (!Number.isNaN(d.getTime())) return d.toISOString().slice(0, 10);
+  return undefined;
+}
+
+function normPhone(raw: string): string | undefined {
+  const digits = raw.replace(/\D/g, '');
+  return digits || undefined;
+}
+
+const NORMALIZERS: Partial<Record<FieldKey, (raw: string) => string | undefined>> = {
+  dob: normDob,
+  country: normCountry,
+  idType: mapIdType,
+  phone: normPhone,
+};
+
+const FIELD_ORDER: FieldKey[] = ['name', 'dob', 'country', 'idType', 'idNumber', 'email', 'phone'];
+
+/**
+ * Ordered by trust/priority — earlier sources win. Each source maps only the
+ * fields it actually carries; to add a source, append an entry with its own
+ * `fields` map.
+ */
+export const KYC_SOURCES: KycSource[] = [
+  {
+    name: 'kycaml-credential',
+    load: async (c, r) => {
+      try {
+        return (await loadKycLevel1Credential(c, r))?.credential ?? null;
+      } catch {
+        return null;
+      }
+    },
+    // SD-JWT credential — claim names. It omits the document number / email / phone.
+    fields: {
+      name: composeName(['given_name'], ['family_name']),
+      dob: ['birth_date'],
+      country: ['nationality', 'birth_country'],
+      idType: ['document_type'],
+    },
+  },
+  {
+    name: 'kyc-pii',
+    load: async (c, r) => {
+      try {
+        return (await loadKycPii(c, r))?.pii ?? null;
+      } catch {
+        return null;
+      }
+    },
+    // Flat PII blob — camelCase + a few snake_case keys. NB: `identifier` (no
+    // suffix) is the street number here, NOT an ID — only `identifier_1` is the
+    // identity-document number.
+    fields: {
+      name: composeName(['givenName', 'given_name', 'first_name'], ['familyName', 'family_name', 'last_name', 'surname'], ['name', 'full_name']),
+      dob: ['birthDate', 'birth_date', 'date_of_birth', 'dob'],
+      country: ['nationality', 'country', 'birth_country'],
+      idType: ['document_type', 'id_type'],
+      idNumber: ['identifier_1', 'document_number', 'id_number', 'identity_number', 'national_id_number'],
+      email: ['email', 'email_address'],
+      phone: ['phone_number', 'phone', 'telephone', 'mobile', 'mobile_number', 'msisdn', 'contact_number'],
+    },
+  },
+];
+
+export async function loadKycPrefill(mxClient: MxClient, roomId: string): Promise<KycPrefill> {
+  // Load every source in priority order (best-effort; failures become null).
+  const records = await Promise.all(
+    KYC_SOURCES.map(async (src) => ({ src, record: await src.load(mxClient, roomId).catch(() => null) })),
+  );
+  if (records.every((r) => !r.record)) return {};
+
+  const out: KycPrefill = {};
+  for (const field of FIELD_ORDER) {
+    for (const { src, record } of records) {
+      const def = record && src.fields[field];
+      if (!def) continue;
+      const raw = extract(record, def);
+      if (!ok(raw)) continue;
+      const normalize = NORMALIZERS[field];
+      const value = normalize ? normalize(String(raw).trim()) : String(raw).trim();
+      if (ok(value)) {
+        out[field] = value;
+        break; // first source with a usable value wins
+      }
+    }
+  }
+  return out;
+}

--- a/utils/matrixCredential.ts
+++ b/utils/matrixCredential.ts
@@ -370,3 +370,123 @@ export async function waitForPiiIndexEntry({
   }
   return false;
 }
+
+// =============================================================================
+// Off-ramp profile — remembered form fields the user typed (bank, account,
+// contact details). Mirrors the PII storage (encrypted timeline blob + state
+// index) but under its own event types and a single fixed state key, since
+// there's just one profile per user (latest wins). This is convenience data the
+// user can override — NOT verified identity.
+// =============================================================================
+
+const OFFRAMP_PROFILE_INDEX_EVENT_TYPE = 'ixo.offramp.profile.index';
+const OFFRAMP_PROFILE_EVENT_TYPE = 'ixo.offramp.profile';
+const OFFRAMP_PROFILE_STATE_KEY = 'yellowcard';
+
+export interface OfframpProfileIndexEntry {
+  eventId: string;
+  cid: string;
+  storedAt: string;
+}
+
+function readOfframpProfileEntries(mxClient: MatrixClient, roomId: string): OfframpProfileIndexEntry[] {
+  try {
+    const room = mxClient.getRoom(roomId);
+    if (!room) return [];
+    const liveState = room.getLiveTimeline().getState(EventTimeline.FORWARDS);
+    const stateEvent = liveState?.getStateEvents(OFFRAMP_PROFILE_INDEX_EVENT_TYPE, OFFRAMP_PROFILE_STATE_KEY);
+    if (!stateEvent) return [];
+    const content = stateEvent.getContent();
+    return Array.isArray(content?.entries) ? (content.entries as OfframpProfileIndexEntry[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Persist the user's off-ramp profile to their matrix room (encrypted timeline
+ * event + a single de-duplicated state index entry, latest wins). Throws if the
+ * room isn't E2EE so callers (best-effort) can swallow it.
+ */
+export async function storeOfframpProfile({
+  mxClient,
+  roomId,
+  profile,
+}: {
+  mxClient: MatrixClient;
+  roomId: string;
+  profile: Record<string, any>;
+}): Promise<{ storedAt: string; duplicate: boolean; eventId: string; cid: string }> {
+  if (!mxClient) throw new Error('Matrix client is not available');
+  if (!roomId) throw new Error('User Matrix room ID is required');
+
+  if (!mxClient.isRoomEncrypted(roomId)) {
+    const msg = `[storeOfframpProfile] Room ${roomId} is not E2EE — off-ramp profile would be written in plaintext`;
+    if (REQUIRE_E2EE_CREDENTIALS) throw new Error(msg);
+    console.warn(msg);
+  }
+
+  const cid = computeCredentialCid(profile);
+  const existingEntries = readOfframpProfileEntries(mxClient, roomId);
+  const duplicate = existingEntries.find((entry) => entry.cid === cid);
+
+  // Always write a fresh encrypted timeline event so the user keeps a copy
+  // decryptable with the current session's megolm keys. The index holds one
+  // entry per CID.
+  const sendResult = await mxClient.sendEvent(roomId, OFFRAMP_PROFILE_EVENT_TYPE as any, {
+    profile: JSON.stringify(profile),
+  });
+  const eventId = sendResult.event_id;
+
+  const storedAt = new Date().toISOString();
+  const indexEntry: OfframpProfileIndexEntry = { eventId, cid, storedAt };
+
+  const nextEntries = duplicate
+    ? existingEntries.map((entry) => (entry.cid === cid ? indexEntry : entry))
+    : [...existingEntries, indexEntry];
+
+  await mxClient.sendStateEvent(
+    roomId,
+    OFFRAMP_PROFILE_INDEX_EVENT_TYPE as any,
+    { entries: nextEntries },
+    OFFRAMP_PROFILE_STATE_KEY,
+  );
+
+  return { storedAt, duplicate: !!duplicate, eventId, cid };
+}
+
+/**
+ * Read and decrypt the user's most-recent off-ramp profile, or null when none
+ * exists / it can't be decrypted on this device.
+ */
+export async function readOfframpProfile(mxClient: MatrixClient, roomId: string): Promise<Record<string, any> | null> {
+  const entries = readOfframpProfileEntries(mxClient, roomId);
+  if (entries.length === 0) return null;
+
+  const entry = [...entries].sort((a, b) => (b.storedAt || '').localeCompare(a.storedAt || ''))[0];
+  if (!entry?.eventId) return null;
+
+  const room = mxClient.getRoom(roomId);
+  if (!room) return null;
+
+  let event = room.findEventById(entry.eventId);
+  if (!event) {
+    const raw = await mxClient.fetchRoomEvent(roomId, entry.eventId);
+    const mapper = mxClient.getEventMapper();
+    event = mapper(raw);
+  }
+
+  if (event.isEncrypted()) {
+    await mxClient.decryptEventIfNeeded(event);
+  }
+  if (event.isDecryptionFailure()) return null;
+
+  const content = event.getContent() as { profile?: string };
+  if (!content?.profile) return null;
+
+  try {
+    return JSON.parse(content.profile);
+  } catch {
+    return null;
+  }
+}

--- a/utils/offrampProfile.ts
+++ b/utils/offrampProfile.ts
@@ -1,0 +1,68 @@
+import { readOfframpProfile, storeOfframpProfile } from '@utils/matrixCredential';
+
+// Reuse the matrix client type the store/read functions expect, rather than
+// re-importing it from matrix-js-sdk (whose named type export doesn't resolve
+// cleanly in this project).
+type MxClient = Parameters<typeof readOfframpProfile>[0];
+
+/**
+ * Remembered off-ramp form fields — the values the user typed last time
+ * (payout bank + account + any contact/identity fields they entered manually).
+ *
+ * This is convenience data the user can override, stored encrypted in their
+ * matrix room (see `storeOfframpProfile`). It's applied on the next visit as
+ * *editable* prefill, and is always lower priority than the verified KYC prefill
+ * (which locks its fields) — so KYC-locked fields are never persisted here.
+ */
+export interface OfframpProfile {
+  /** Payout country (ISO alpha-2). */
+  country?: string;
+  /** Selected bank network id. */
+  networkId?: string;
+  /** Selected bank display name. */
+  bankName?: string;
+  accountNumber?: string;
+  accountName?: string;
+  /** Contact / identity fields — only persisted when not locked by KYC. */
+  name?: string;
+  phone?: string;
+  email?: string;
+  /** YYYY-MM-DD. */
+  dob?: string;
+  /** Sender nationality (ISO alpha-2). */
+  nationality?: string;
+  idType?: string;
+  idNumber?: string;
+  bvn?: string;
+}
+
+/** Best-effort read of the saved profile; null on absence / decryption failure. */
+export async function loadOfframpProfile(mxClient: MxClient, roomId: string): Promise<OfframpProfile | null> {
+  try {
+    const raw = await readOfframpProfile(mxClient, roomId);
+    return raw ? (raw as OfframpProfile) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Best-effort save of the profile — drops empty values, no-ops on an empty
+ * payload, and never throws (e.g. when the room's encryption isn't ready). Must
+ * not block the withdrawal flow.
+ */
+export async function saveOfframpProfile(mxClient: MxClient, roomId: string, profile: OfframpProfile): Promise<void> {
+  try {
+    const clean: Record<string, string> = {};
+    (Object.keys(profile) as (keyof OfframpProfile)[]).forEach((key) => {
+      const value = profile[key];
+      if (value !== undefined && value !== null && String(value).trim() !== '') {
+        clean[key] = String(value).trim();
+      }
+    });
+    if (Object.keys(clean).length === 0) return;
+    await storeOfframpProfile({ mxClient, roomId, profile: clean });
+  } catch {
+    /* best-effort — never block on persistence */
+  }
+}

--- a/utils/ucanYellowcard.ts
+++ b/utils/ucanYellowcard.ts
@@ -1,0 +1,71 @@
+import { createInvocation, serializeInvocation, signerFromMnemonic, type Capability, type SupportedDID } from '@ixo/ucan';
+
+import authConstants from '@constants/auth';
+import { YELLOWCARD_WORKER_API } from '@constants/yellowcard';
+import { secureLoad } from '@utils/storage';
+
+/**
+ * UCAN invocation minting for the YellowCard off-ramp worker.
+ *
+ * Mirrors `@utils/ucan` (the KYC flow): the user's Ed25519 `ED_SIGNING_MNEMONIC`
+ * is kept in secure storage in plaintext (decrypted at auth-hub login), so we
+ * mint invocations directly — no PIN prompt. The off-ramp routes are
+ * user-rooted (worker rootMode 'any'), so the user is the root issuer and no
+ * proof delegation is needed.
+ */
+
+let cachedWorkerDid: string | null = null;
+
+/** Resolve the worker's `did:web` from its published DID document. Cached for
+ *  the page lifetime. */
+export async function resolveWorkerDid(): Promise<string> {
+  if (cachedWorkerDid) return cachedWorkerDid;
+  const base = YELLOWCARD_WORKER_API.replace(/\/+$/, '');
+  const res = await fetch(`${base}/.well-known/did.json`);
+  if (!res.ok) throw new Error(`Failed to fetch YellowCard worker DID: ${res.status}`);
+  const doc = await res.json();
+  const did = doc?.id;
+  if (typeof did !== 'string' || !did.startsWith('did:')) {
+    throw new Error('Malformed YellowCard worker DID document');
+  }
+  cachedWorkerDid = did;
+  return did;
+}
+
+/**
+ * Generate a UCAN-unique nonce. The worker indexes invocations by CID for
+ * replay protection; without a per-call nonce, two requests built within the
+ * same wall-clock second produce identical UCANs and the second fails as a
+ * replay. `facts` are included in the CID, so a `{ nonce }` fact disambiguates
+ * parallel calls.
+ */
+function generateNonce(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') return globalThis.crypto.randomUUID();
+  const bytes = new Uint8Array(16);
+  globalThis.crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+const OFFRAMP_CAPABILITY: Capability = { can: 'yellowcard/offramp', with: 'ixo:yellowcard' };
+
+/**
+ * Mint a fresh single-use invocation CAR (bearer token) for the off-ramp
+ * capability, signed by the user's Ed25519 key.
+ */
+export async function mintOfframpBearer(userDid: string): Promise<string> {
+  const mnemonic = secureLoad(authConstants.secretKey.ED_SIGNING_MNEMONIC);
+  if (!mnemonic) throw new Error('Signing mnemonic not available — please sign in again');
+
+  const workerDid = await resolveWorkerDid();
+  const { signer } = await signerFromMnemonic(String(mnemonic).trim(), userDid as SupportedDID);
+
+  const invocation = await createInvocation({
+    issuer: signer,
+    audience: workerDid,
+    capability: OFFRAMP_CAPABILITY,
+    expiration: Math.floor(Date.now() / 1000) + 300,
+    facts: [{ nonce: generateNonce() }],
+  });
+
+  return serializeInvocation(invocation);
+}

--- a/utils/usdcBalance.ts
+++ b/utils/usdcBalance.ts
@@ -1,0 +1,30 @@
+import { createQueryClient } from '@ixo/impactxclient-sdk';
+
+import { CHAIN_RPC_URL } from '@constants/common';
+import { IXO_USDC_DENOM } from '@constants/yellowcard';
+
+export interface UsdcBalance {
+  /** The denom actually held (the canonical mainnet USDC IBC denom). */
+  denom: string;
+  /** Balance in micro-USDC (6 decimals). */
+  amountMicro: string;
+  /** Balance in whole USDC. */
+  amount: number;
+}
+
+/**
+ * Read the user's ixo USDC balance (canonical mainnet IBC denom). Returns a
+ * zero balance on any query failure so the UI can render without throwing.
+ */
+export async function getUsdcBalance(address: string): Promise<UsdcBalance> {
+  const zero: UsdcBalance = { denom: IXO_USDC_DENOM, amountMicro: '0', amount: 0 };
+  if (!address) return zero;
+  try {
+    const queryClient = await createQueryClient(CHAIN_RPC_URL);
+    const res = await queryClient.cosmos.bank.v1beta1.balance({ address, denom: IXO_USDC_DENOM });
+    const micro = res?.balance?.amount ?? '0';
+    return { denom: IXO_USDC_DENOM, amountMicro: micro, amount: Number(micro) / 1e6 };
+  } catch {
+    return zero;
+  }
+}


### PR DESCRIPTION
## What

Adds a YellowCard fiat off-ramp to the Yoma profile (`/profile/offramp`): sell USDC held on ixo to a local bank account.

## How it works

- **Bridge + sell**: Skip Go bridges ixo USDC → Base USDC, which funds a UCAN-gated YellowCard `directSettlement` sell created via the worker. Single bridge tx is signed with the auth-hub session key.
- **KYC gate**: withdrawals require a KYC credential. Without one, the form is replaced by a prompt linking to `/profile` to check verification status.
- **Prefill**: verified identity (KYC credential + PII) auto-fills and **locks** name/DOB/country/ID type/ID number/email (green `*` tooltip). Remaining fields are editable.
- **Saved profile**: fields the user types (bank, account, contact) are persisted encrypted in their Matrix room (`ixo.offramp.profile`, mirroring the PII pattern) and recalled on the next visit as editable, overridable prefill.
- **Auth hub**: login redirect now passes `hide_mnemonic=true` to skip the recovery-phrase screen during registration.

## Notes

- Mainnet-only (worker + Skip routes are `ixo-5`); other networks show an alert.
- No new dependencies (Skip via plain fetch through the worker proxy).
- typecheck + lint clean (no new errors); not yet exercised end-to-end against a funded mainnet account.

Authored by: Michael Pretorius <michael@ixo.world>