### PR TITLE
feat(offramp): present KYC SD-JWT to the worker on withdrawal

### DIFF
--- a/hooks/useOfframp.ts
+++ b/hooks/useOfframp.ts
@@ -52,6 +52,9 @@ export interface WithdrawParams {
   sourceDenom?: string;
   customer: OfframpCustomer;
   destination: OfframpDestination;
+  /** The user's KYC SD-JWT presentation — the worker verifies it against our
+   *  oracle and binds it to the caller's DID before creating the payout. */
+  kycCredential: string;
 }
 
 /** Preview combining BOTH legs: the Skip bridge (ixo→Base) fee and the YC
@@ -188,6 +191,7 @@ export default function useOfframp() {
             network: OFFRAMP_DESTINATION.cryptoNetwork,
             customer: params.customer,
             destination: params.destination,
+            kycCredential: params.kycCredential,
           },
           createBearer,
         );

--- a/lib/yellowcard/offrampClient.ts
+++ b/lib/yellowcard/offrampClient.ts
@@ -150,6 +150,10 @@ export function createOfframp(
     customerType?: string;
     customer: OfframpCustomer;
     destination: OfframpDestination;
+    /** The user's KYC credential as the full canonical SD-JWT presentation
+     *  (`<jwt>~<disclosure>~…`). The worker verifies it against our oracle and
+     *  binds it to the caller's DID before creating the payout. */
+    kycCredential: string;
   },
   bearer: string,
 ): Promise<CreateResult> {

--- a/screens/offramp.tsx
+++ b/screens/offramp.tsx
@@ -21,6 +21,7 @@ import {
 } from 'lib/yellowcard/offrampClient';
 import { ALL_COUNTRY_OPTIONS, countryOptions } from '@utils/countries';
 import { type KycPrefill, hasKycCredential, loadKycPrefill } from '@utils/kycPrefill';
+import { loadKycCredentialJwt } from '@utils/approvePayment';
 import { type OfframpProfile, loadOfframpProfile, saveOfframpProfile } from '@utils/offrampProfile';
 import { getUsdcBalance } from '@utils/usdcBalance';
 
@@ -101,6 +102,8 @@ export default function OfframpScreen() {
   const [prefill, setPrefill] = useState<KycPrefill | null>(null);
   // KYC gate: null = still checking, true/false = whether they hold a credential.
   const [hasKyc, setHasKyc] = useState<boolean | null>(null);
+  // The raw KYC SD-JWT presentation, sent to the worker to verify at payout time.
+  const [kycCredentialJwt, setKycCredentialJwt] = useState<string | null>(null);
   // Remembered fields from a previous withdrawal (editable, overridable). Lower
   // priority than KYC prefill — only fills fields KYC didn't lock.
   const [savedProfile, setSavedProfile] = useState<OfframpProfile | null>(null);
@@ -164,6 +167,9 @@ export default function OfframpScreen() {
         if (!owns) return;
         const result = await loadKycPrefill(mxClient, matrixRoomId);
         if (!cancelled) setPrefill(result);
+        // The raw SD-JWT to present to the worker's KYC gate at payout time.
+        const jwt = await loadKycCredentialJwt(mxClient, matrixRoomId).catch(() => null);
+        if (!cancelled) setKycCredentialJwt(jwt);
       } catch {
         /* best-effort — leave the gate "checking" if matrix isn't reachable */
       }
@@ -368,7 +374,10 @@ export default function OfframpScreen() {
     !!kycDob &&
     !!kycCountry &&
     !!kycIdNumber &&
-    (!isNG || !!kycBvn);
+    (!isNG || !!kycBvn) &&
+    // The worker requires the KYC SD-JWT; don't let a payout be attempted
+    // without it (the testing bypass skips this client-side check).
+    (BYPASS_KYC_CHECK || !!kycCredentialJwt);
 
   const busy = offramp.stage !== 'idle' && offramp.stage !== 'submitted' && offramp.stage !== 'error';
 
@@ -457,6 +466,7 @@ export default function OfframpScreen() {
         currency,
         channelType,
         sourceDenom: heldDenom,
+        kycCredential: kycCredentialJwt ?? '',
         customer: {
           name: kycName,
           country: kycCountry,

--- a/utils/approvePayment.ts
+++ b/utils/approvePayment.ts
@@ -262,3 +262,20 @@ export async function loadKycLevel1Credential(
   }
   return { eventId: entry.eventId, credential };
 }
+
+/**
+ * The raw KYC SD-JWT presentation string (`<jwt>~<disclosure>~…`) to send to a
+ * verifier (e.g. the YellowCard worker's KYC gate). For an SD-JWT record the
+ * raw credential lives in the record's `credential` field. Returns null when no
+ * credential is held; throws only if it's present but undecryptable.
+ */
+export async function loadKycCredentialJwt(
+  mxClient: MatrixClient,
+  roomId: string,
+): Promise<string | null> {
+  const loaded = await loadKycLevel1Credential(mxClient, roomId);
+  const record = loaded?.credential;
+  if (!record) return null;
+  const raw = record.credential;
+  return typeof raw === 'string' && raw.includes('~') ? raw : null;
+}


### PR DESCRIPTION
## What

Sends the user's KYC credential to the YellowCard worker so it can verify it at payout time (pairs with the worker's new KYC gate on `POST /offramp/create`).

- `utils/approvePayment.ts` — `loadKycCredentialJwt()` returns the raw SD-JWT presentation string (`<jwt>~<disclosure>~…`) from the user's Matrix-stored credential record (the inner `credential` field only — not the wrapper JSON).
- `screens/offramp.tsx` — loads that string alongside the existing KYC prefill and includes it in the withdrawal; `canWithdraw` now requires it (the testing bypass still skips the client-side check).
- `hooks/useOfframp.ts` + `lib/yellowcard/offrampClient.ts` — thread `kycCredential` through `withdraw` → `createOfframp` into the `/offramp/create` body.

The worker verifies it against our KYC oracle and binds it to the caller's DID before creating any payout; a request without it is rejected.

Authored by: Michael Pretorius <michael@ixo.world>