### PR TITLE
feat(onramp): deposit flow — pay local fiat, receive USDC on ixo

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,12 @@ NEXT_PUBLIC_JAMBO_WORKER_URL=""
 #   mainnet https://email.notifications.ixo.earth
 NEXT_PUBLIC_EMAIL_NOTIFIER_URL=""
 
+# YellowCard worker base URL (deposit/buy + withdraw/sell flows). OPTIONAL —
+# leave blank to use the network default (constants/yellowcard.ts):
+#   mainnet https://yellowcard.worker.ixo.earth
+#   testnet https://test.yellowcard.worker.ixo.earth
+NEXT_PUBLIC_YELLOWCARD_WORKER_API=""
+
 # Approve-Payment collection: when the user starts a claim against this collection,
 # the form auto-pulls data from one of their own claims in the source collections
 # below (and their kycamllevel1 credential data) to map into the new claim's fields.

--- a/constants/yellowcard.ts
+++ b/constants/yellowcard.ts
@@ -43,4 +43,24 @@ export const OFFRAMP_DESTINATION = {
 };
 
 /** Off-ramp end-states (mirror the worker). Anything else is still in-flight. */
-export const TERMINAL_OFFRAMP_STATUSES = new Set(['completed', 'failed', 'expired', 'refunded', 'refund_failed', 'cancelled']);
+export const TERMINAL_OFFRAMP_STATUSES = new Set([
+  'completed',
+  'failed',
+  'expired',
+  'refunded',
+  'refund_failed',
+  'cancelled',
+]);
+
+/** On-ramp end-states (mirror the worker). `delivered` = USDC arrived on ixo.
+ *  `bridge_failed` is ops-parked (support will resolve it), so the UI treats it
+ *  as no-longer-in-flight too. */
+export const TERMINAL_ONRAMP_STATUSES = new Set([
+  'delivered',
+  'failed',
+  'expired',
+  'cancelled',
+  'refunded',
+  'refund_failed',
+  'bridge_failed',
+]);

--- a/hooks/useOnramp.ts
+++ b/hooks/useOnramp.ts
@@ -1,0 +1,133 @@
+import { useCallback, useState } from 'react';
+
+import { useAuth } from '@hooks/useAuth';
+import {
+  type OfframpCustomer,
+  type OnrampQuoteResult,
+  type OnrampSource,
+  type OnrampTransaction,
+  createOnramp,
+  getOnramp,
+  listOnramps,
+  quoteOnramp,
+} from 'lib/yellowcard/offrampClient';
+import { mintOnrampBearer } from '@utils/ucanYellowcard';
+
+/** In-flight stage of a deposit, for UI feedback. */
+export type OnrampStage = 'idle' | 'authorizing' | 'creating' | 'submitted' | 'error';
+
+export interface DepositParams {
+  /** Local fiat the user will pay (YC locks the rate for ~10 min). */
+  localAmount: number;
+  currency: string;
+  country: string;
+  /** Payment rail (bank | momo). */
+  channelType: string;
+  source: OnrampSource;
+  customer: OfframpCustomer;
+  /** Where a hosted payment page (ZA) returns the user to. */
+  returnUrl?: string;
+  /** The user's KYC SD-JWT presentation — verified by the worker's gate. */
+  kycCredential: string;
+}
+
+/**
+ * YellowCard on-ramp orchestration for jambo. Far simpler than the off-ramp:
+ * no signing and no Skip work happen client-side — the worker receives the
+ * USDC on Base and bridges it to the user's ixo address itself. The frontend
+ * only creates the collection and shows payment instructions + status.
+ */
+export default function useOnramp() {
+  const { address, did } = useAuth();
+
+  const [stage, setStage] = useState<OnrampStage>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [transactions, setTransactions] = useState<OnrampTransaction[]>([]);
+  const [active, setActive] = useState<OnrampTransaction | null>(null);
+
+  const mintBearer = useCallback(async (): Promise<string> => {
+    if (!did) throw new Error('Not signed in');
+    return mintOnrampBearer(did);
+  }, [did]);
+
+  const refreshTransactions = useCallback(async () => {
+    const bearer = await mintBearer();
+    const res = await listOnramps(bearer);
+    setTransactions(res.transactions);
+    return res.transactions;
+  }, [mintBearer]);
+
+  const previewDeposit = useCallback(
+    async (params: {
+      localAmount: number;
+      currency: string;
+      channelType: string;
+      country: string;
+    }): Promise<OnrampQuoteResult> => {
+      const bearer = await mintBearer();
+      return quoteOnramp(params, bearer);
+    },
+    [mintBearer],
+  );
+
+  /** Create the YC collection. The returned transaction carries the payment
+   *  instructions (bank account + reference / payment link / momo prompt) and
+   *  the EXACT USDC the user will receive — shown before they pay anything. */
+  const deposit = useCallback(
+    async (params: DepositParams): Promise<OnrampTransaction> => {
+      if (!address) throw new Error('Wallet address not available');
+      setError(null);
+      try {
+        setStage('authorizing');
+        const bearer = await mintBearer();
+        setStage('creating');
+        const created = await createOnramp(
+          {
+            localAmount: params.localAmount,
+            currency: params.currency,
+            country: params.country,
+            channelType: params.channelType,
+            ixoAddress: address,
+            source: params.source,
+            customer: params.customer,
+            returnUrl: params.returnUrl,
+            kycCredential: params.kycCredential,
+          },
+          bearer,
+        );
+        setActive(created.transaction);
+        setStage('submitted');
+        await refreshTransactions().catch(() => undefined);
+        return created.transaction;
+      } catch (err) {
+        setStage('error');
+        setError(err instanceof Error ? err.message : 'Deposit failed');
+        throw err;
+      }
+    },
+    [address, mintBearer, refreshTransactions],
+  );
+
+  const pollTransaction = useCallback(
+    async (id: string): Promise<OnrampTransaction> => {
+      const bearer = await mintBearer();
+      const res = await getOnramp(id, bearer);
+      return res.transaction;
+    },
+    [mintBearer],
+  );
+
+  const clearError = useCallback(() => setError(null), []);
+
+  return {
+    stage,
+    error,
+    active,
+    transactions,
+    previewDeposit,
+    deposit,
+    refreshTransactions,
+    pollTransaction,
+    clearError,
+  };
+}

--- a/lib/yellowcard/offrampClient.ts
+++ b/lib/yellowcard/offrampClient.ts
@@ -1,9 +1,9 @@
 import { YELLOWCARD_WORKER_API } from '@constants/yellowcard';
 
 /**
- * Thin client for the YellowCard worker's off-ramp endpoints. The off-ramp
- * routes are UCAN-gated (rootMode 'any') — pass a freshly-minted invocation
- * CAR as the bearer. `/channels` and `/countries` are public.
+ * Thin client for the YellowCard worker's off-ramp AND on-ramp endpoints.
+ * The ramp routes are UCAN-gated (rootMode 'any') — pass a freshly-minted
+ * invocation CAR as the bearer. `/channels` and `/countries` are public.
  */
 
 const BASE = YELLOWCARD_WORKER_API.replace(/\/+$/, '');
@@ -186,7 +186,9 @@ export async function fetchPaymentRecordPdf(id: string, bearer: string): Promise
   return res.blob();
 }
 
-export function listOfframps(bearer: string): Promise<{ success: true; count: number; transactions: OfframpTransaction[] }> {
+export function listOfframps(
+  bearer: string,
+): Promise<{ success: true; count: number; transactions: OfframpTransaction[] }> {
   return get(`/offramp/transactions`, bearer);
 }
 
@@ -231,10 +233,10 @@ export interface YcChannel {
   estimatedSettlementTime?: number;
 }
 
-/** Public: the YC-supported off-ramp country codes (ISO alpha-2). Maintained
- *  server-side so the list can be updated without a frontend release. */
-export async function fetchSupportedCountries(): Promise<string[]> {
-  const res = await fetch(`${BASE}/countries`);
+/** Public: the YC-supported country codes (ISO alpha-2) for a ramp direction.
+ *  Maintained server-side so the list can change without a frontend release. */
+export async function fetchSupportedCountries(ramp: 'offramp' | 'onramp' = 'offramp'): Promise<string[]> {
+  const res = await fetch(`${BASE}/countries${ramp === 'onramp' ? '?ramp=onramp' : ''}`);
   const text = await res.text();
   const json = text ? JSON.parse(text) : null;
   if (!res.ok) {
@@ -243,15 +245,148 @@ export async function fetchSupportedCountries(): Promise<string[]> {
   return Array.isArray(json?.countries) ? json.countries : [];
 }
 
-export async function discoverChannels(country: string): Promise<{ channels: YcChannel[]; networks: YcNetwork[] }> {
-  const json = await post<{ results?: Array<{ success?: boolean; country?: string; channels?: unknown; networks?: unknown }> }>('/channels', {
+/** Discover a country's active channels + networks. `rampType` selects the
+ *  direction: 'withdraw' (off-ramp payouts, default) or 'deposit' (on-ramp). */
+export async function discoverChannels(
+  country: string,
+  rampType: 'withdraw' | 'deposit' = 'withdraw',
+): Promise<{ channels: YcChannel[]; networks: YcNetwork[] }> {
+  const json = await post<{
+    results?: Array<{ success?: boolean; country?: string; channels?: unknown; networks?: unknown }>;
+  }>('/channels', {
     countries: [country.toUpperCase()],
+    rampType,
   });
   const entry = (json.results ?? []).find((r) => r?.success);
   const arr = (v: unknown): any[] =>
-    Array.isArray(v) ? v : Array.isArray((v as any)?.channels) ? (v as any).channels : Array.isArray((v as any)?.networks) ? (v as any).networks : [];
+    Array.isArray(v)
+      ? v
+      : Array.isArray((v as any)?.channels)
+      ? (v as any).channels
+      : Array.isArray((v as any)?.networks)
+      ? (v as any).networks
+      : [];
   return {
     channels: arr(entry?.channels) as YcChannel[],
     networks: arr(entry?.networks) as YcNetwork[],
   };
+}
+
+// ---------------------------------------------------------------------------
+// On-ramp (pay local fiat → receive USDC on ixo)
+// ---------------------------------------------------------------------------
+
+export interface OnrampSource {
+  accountType: 'bank' | 'momo';
+  /** Momo: the payer's mobile-money number in international format (+…). */
+  accountNumber?: string;
+  /** Momo: the mobile-money provider (YC network id). */
+  networkId?: string;
+  /** Display name of the provider — stored for history only. */
+  networkName?: string;
+}
+
+export interface OnrampTransaction {
+  id: string;
+  status: string;
+  yc_collection_id: string | null;
+  /** Payment rail ('bank' | 'momo'). */
+  channel_type: string | null;
+  /** Local currency the user pays in. */
+  currency: string | null;
+  country: string | null;
+  /** Local fiat the user pays. */
+  local_amount: number | null;
+  /** Gross USD equivalent. */
+  amount_usd: number | null;
+  rate: number | null;
+  service_fee_usd: number | null;
+  /** YC's crypto-send network fee. */
+  network_fee_usd: number | null;
+  partner_fee_usd: number | null;
+  /** EXACT USDC YellowCard sends after its fees (pre bridge fee). */
+  crypto_amount: number | null;
+  /** Our flat bridge fee, withheld from the delivery. */
+  bridge_fee_usd: number | null;
+  /** USDC delivered to the user's ixo account. */
+  net_usdc: number | null;
+  crypto_currency: string;
+  crypto_network: string;
+  /** The ixo address the USDC is delivered to. */
+  ixo_address: string | null;
+  source: unknown;
+  /** YC bankInfo — the account to pay INTO (bank rails), or { paymentLink }. */
+  bank_info: { name?: string; accountNumber?: string; accountName?: string; paymentLink?: string } | null;
+  /** Payment reference the user must include (bank rails). */
+  reference: string | null;
+  /** Hosted payment page (redirect channels, e.g. South Africa). */
+  payment_link: string | null;
+  settlement_tx_hash: string | null;
+  bridge_tx_hash: string | null;
+  bridge_status: string | null;
+  error: string | null;
+  error_detail: string | null;
+  /** Deadline for the user's payment / YC acceptance (unix seconds). */
+  expires_at: number | null;
+  created_at: number;
+  updated_at: number;
+}
+
+export interface OnrampQuoteResult {
+  success: true;
+  currency: string;
+  localAmount: number;
+  amountUsd?: number;
+  rateLocal?: number;
+  serviceFeeLocal?: number;
+  serviceFeeUSD?: number;
+  partnerFeeLocal?: number;
+  partnerFeeUSD?: number;
+  /** Estimate only — the create response carries the exact network fee. */
+  networkFeeUSDEstimate?: number;
+  bridgeFeeUsd?: number;
+  /** Estimated USDC delivered to the user's ixo account. */
+  estimatedUsdcReceive?: number;
+  /** Min/max in local currency. */
+  transactionLimitMin?: number | null;
+  transactionLimitMax?: number | null;
+}
+
+export function quoteOnramp(
+  body: { localAmount: number; currency: string; channelType: string; country: string },
+  bearer: string,
+): Promise<OnrampQuoteResult> {
+  return post<OnrampQuoteResult>('/onramp/quote', body, bearer);
+}
+
+export function createOnramp(
+  body: {
+    /** Local fiat the user will pay — fixed for the user; YC locks the rate. */
+    localAmount: number;
+    currency: string;
+    country: string;
+    channelType: string;
+    /** The user's ixo address the bridged USDC is delivered to. */
+    ixoAddress: string;
+    source: OnrampSource;
+    customerType?: string;
+    customer: OfframpCustomer;
+    /** Where a hosted payment page (ZA) returns the user to. */
+    returnUrl?: string;
+    /** The user's KYC SD-JWT presentation — same gate as the off-ramp. */
+    kycCredential: string;
+  },
+  bearer: string,
+): Promise<{ success: true; transaction: OnrampTransaction }> {
+  return post('/onramp/create', body, bearer);
+}
+
+export function listOnramps(
+  bearer: string,
+): Promise<{ success: true; count: number; transactions: OnrampTransaction[] }> {
+  return get(`/onramp/transactions`, bearer);
+}
+
+export function getOnramp(id: string, bearer: string): Promise<{ success: true; transaction: OnrampTransaction }> {
+  return get(`/onramp/${id}`, bearer);
 }

--- a/pages/profile/onramp.tsx
+++ b/pages/profile/onramp.tsx
@@ -1,0 +1,10 @@
+import AuthGuard from '@components/AuthGuard';
+import OnrampScreen from 'screens/onramp';
+
+export default function OnrampPage() {
+  return (
+    <AuthGuard>
+      <OnrampScreen />
+    </AuthGuard>
+  );
+}

--- a/screens/offramp.tsx
+++ b/screens/offramp.tsx
@@ -20,7 +20,7 @@ import {
   fetchSupportedCountries,
 } from 'lib/yellowcard/offrampClient';
 import { ALL_COUNTRY_OPTIONS, countryOptions } from '@utils/countries';
-import { type KycPrefill, hasKycCredential, loadKycPrefill } from '@utils/kycPrefill';
+import { type KycPrefill, loadKycPrefill, waitForKycCredential } from '@utils/kycPrefill';
 import { loadKycCredentialJwt } from '@utils/approvePayment';
 import { type OfframpProfile, loadOfframpProfile, saveOfframpProfile } from '@utils/offrampProfile';
 import { getUsdcBalance } from '@utils/usdcBalance';
@@ -210,8 +210,10 @@ export default function OfframpScreen() {
         await awaitCompletion();
         const mxClient = getMatrixClient();
         if (cancelled || !mxClient) return;
-        // Gate first (cheap, unencrypted index read), then prefill if they qualify.
-        const owns = hasKycCredential(mxClient, matrixRoomId);
+        // Gate first (cheap, unencrypted index read), then prefill if they
+        // qualify. Waits out a still-syncing client — a one-shot read right
+        // after login can miss room state and wrongly gate a KYC'd user.
+        const owns = await waitForKycCredential(mxClient, matrixRoomId, { cancelled: () => cancelled });
         if (cancelled) return;
         setHasKyc(owns);
         // setHasKyc(false);
@@ -345,7 +347,9 @@ export default function OfframpScreen() {
     const net = bankNetworks.find((n) => n.id === networkId);
     if (!net) return [];
     const ids = new Set(networkChannelIds(net));
-    return channels.filter((c) => ids.has(c.id) && isActiveWithdrawChannel(c) && mapCategory(c.channelType) === payoutMethod);
+    return channels.filter(
+      (c) => ids.has(c.id) && isActiveWithdrawChannel(c) && mapCategory(c.channelType) === payoutMethod,
+    );
   }, [networkId, bankNetworks, channels, payoutMethod]);
 
   const currency = useMemo(() => channelCandidates.find((c) => c.currency)?.currency ?? '', [channelCandidates]);
@@ -496,7 +500,11 @@ export default function OfframpScreen() {
     if (!matrixRoomId) return;
     const mxClient = getMatrixClient();
     if (!mxClient) return;
+    // The store is whole-blob latest-wins (no server-side merge), so spread
+    // the loaded profile first — otherwise saving withdraw fields would WIPE
+    // the deposit flow's saved onramp* keys.
     void saveOfframpProfile(mxClient, matrixRoomId, {
+      ...(savedProfile ?? {}),
       country,
       payoutMethod,
       networkId,
@@ -515,6 +523,7 @@ export default function OfframpScreen() {
   }, [
     matrixRoomId,
     getMatrixClient,
+    savedProfile,
     country,
     payoutMethod,
     networkId,
@@ -855,13 +864,17 @@ export default function OfframpScreen() {
 
                       {networkId && channelCandidates.length === 0 && (
                         <span className={styles.warnLine}>
-                          {isMomo ? 'No active withdraw channel for this provider.' : 'No active withdraw channel for this bank.'}
+                          {isMomo
+                            ? 'No active withdraw channel for this provider.'
+                            : 'No active withdraw channel for this bank.'}
                         </span>
                       )}
 
                       <div className={styles.row}>
                         <div className={styles.field}>
-                          <label className={styles.label}>{isMomo ? 'Mobile money number' : 'Bank account number'}</label>
+                          <label className={styles.label}>
+                            {isMomo ? 'Mobile money number' : 'Bank account number'}
+                          </label>
                           {isMomo ? (
                             <div
                               className={`${styles.inputPrefixWrap}${

--- a/screens/onramp.tsx
+++ b/screens/onramp.tsx
@@ -1,0 +1,1236 @@
+import { type ReactNode, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { useRouter } from 'next/router';
+
+import { BackgroundSetupContext } from '@contexts/backgroundSetup';
+import Header from '@components/Header/Header';
+import Loader from '@components/Loader/Loader';
+import Button, { BUTTON_BG_COLOR, BUTTON_BORDER_COLOR, BUTTON_COLOR, BUTTON_SIZE } from '@components/Button/Button';
+import { CHAIN_NETWORK_TYPE, DefaultChainNetwork } from '@constants/common';
+import { TERMINAL_ONRAMP_STATUSES } from '@constants/yellowcard';
+import { useAuth } from '@hooks/useAuth';
+import useOnramp from '@hooks/useOnramp';
+import {
+  type OnrampQuoteResult,
+  type YcChannel,
+  type YcNetwork,
+  discoverChannels,
+  fetchSupportedCountries,
+} from 'lib/yellowcard/offrampClient';
+import { ALL_COUNTRY_OPTIONS, countryOptions } from '@utils/countries';
+import { type KycPrefill, loadKycPrefill, waitForKycCredential } from '@utils/kycPrefill';
+import { loadKycCredentialJwt } from '@utils/approvePayment';
+import { type OfframpProfile, loadOfframpProfile, saveOfframpProfile } from '@utils/offrampProfile';
+
+import styles from '@styles/Offramp.module.scss';
+
+// Sender ID types — NIN is auto-applied (with BVN) when the user's own country
+// is Nigeria, same as the withdraw flow.
+const ID_TYPE_OPTIONS = [
+  { value: 'passport', label: 'Passport' },
+  { value: 'national_id', label: 'National ID' },
+  { value: 'drivers_license', label: "Driver's license" },
+];
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const VERIFIED_LABEL = 'From your verified identity';
+const KYC_INFO_LABEL =
+  'We’ve filled in and locked the details from your verified identity. Complete any remaining fields below.';
+const ESTIMATE_NOTE =
+  'Estimated — you’ll see the exact amount you’ll receive before you pay (the rate locks when you continue).';
+
+function networkChannelIds(network: YcNetwork): string[] {
+  if (Array.isArray(network.channelIds)) return network.channelIds.filter(Boolean);
+  if (network.channelId) return [network.channelId];
+  return [];
+}
+
+type PayMethod = 'bank' | 'momo';
+
+const PAY_METHOD_LABEL: Record<PayMethod, string> = {
+  bank: 'Bank transfer',
+  momo: 'Mobile money',
+};
+
+/** Collapse YC's concrete channel types (bank, p2p, virtualbank, momo, …) to
+ *  the two rails we offer — same rule as the withdraw screen + worker. */
+function mapCategory(channelType: string | null | undefined): PayMethod {
+  return (channelType ?? '').toLowerCase() === 'momo' ? 'momo' : 'bank';
+}
+
+function networkMethod(network: YcNetwork): PayMethod {
+  return mapCategory(network.channelType);
+}
+
+/** Only ACTIVE DEPOSIT channels count for paying in. The worker filters too,
+ *  but never trust that here — an unfiltered list once let this screen offer
+ *  a country whose deposit channels were all inactive in production. */
+function isActiveDepositChannel(c: YcChannel): boolean {
+  return (
+    (c.status ? c.status.toLowerCase() === 'active' : false) &&
+    (c.rampType ? c.rampType.toLowerCase() === 'deposit' : false)
+  );
+}
+
+/** Safe dropdown label (`code` can be a {branch: code} object — see withdraw). */
+function networkLabel(n: YcNetwork): string {
+  const name = n.name ?? n.id;
+  const code = typeof n.code === 'string' ? n.code : '';
+  return code ? `${name} (${code})` : name;
+}
+
+function formatDob(value: string): string {
+  // <input type="date"> gives YYYY-MM-DD; YC expects MM/DD/YYYY.
+  const m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!m) return '';
+  return `${m[2]}/${m[3]}/${m[1]}`;
+}
+
+function formatUsdc(amount: number): string {
+  return amount.toLocaleString(undefined, { maximumFractionDigits: 6 });
+}
+
+/** Statuses where the user still needs to pay (payment instructions shown). */
+const AWAITING_PAYMENT_STATUSES = new Set(['created', 'pending_approval', 'process', 'processing', 'pending']);
+
+/** User-facing status label — the raw lifecycle values are worker/YC jargon. */
+function statusLabel(status: string): string {
+  switch (status) {
+    case 'created':
+    case 'pending_approval':
+    case 'process':
+    case 'processing':
+      return 'processing';
+    case 'pending':
+      return 'awaiting payment';
+    case 'complete':
+      return 'payment received';
+    case 'settlement_pending':
+    case 'settlement_processing':
+      return 'converting';
+    case 'settlement_complete':
+    case 'bridging':
+      return 'delivering';
+    case 'delivered':
+      return 'delivered';
+    case 'bridge_failed':
+      return 'delivery issue';
+    default:
+      return status.replace(/_/g, ' ');
+  }
+}
+
+export default function OnrampScreen() {
+  const router = useRouter();
+  const { address, matrixRoomId } = useAuth();
+  const { getMatrixClient, awaitCompletion } = useContext(BackgroundSetupContext);
+  const onramp = useOnramp();
+
+  // The on-ramp is mainnet-only: the bridge leg (Base→ixo) doesn't exist on
+  // testnet. No test scaffolding here — small prod amounts are the smoke test.
+  const onrampEnabled = DefaultChainNetwork === CHAIN_NETWORK_TYPE.MAINNET;
+
+  const [amount, setAmount] = useState<string>('');
+  const [country, setCountry] = useState<string>('KE');
+  const [supportedOptions, setSupportedOptions] = useState<{ value: string; label: string }[]>([]);
+  const [networks, setNetworks] = useState<YcNetwork[]>([]);
+  const [channels, setChannels] = useState<YcChannel[]>([]);
+  const [loadingChannels, setLoadingChannels] = useState(false);
+  const [payMethod, setPayMethod] = useState<PayMethod>('bank');
+  const [networkId, setNetworkId] = useState<string>('');
+  // The mobile-money number the user pays FROM (digits, international format).
+  const [momoNumber, setMomoNumber] = useState('');
+
+  const [kycName, setKycName] = useState('');
+  const [kycPhone, setKycPhone] = useState('');
+  const [kycEmail, setKycEmail] = useState('');
+  const [kycDob, setKycDob] = useState('');
+  const [kycCountry, setKycCountry] = useState('ZA');
+  const [kycIdType, setKycIdType] = useState('passport');
+  const [kycIdNumber, setKycIdNumber] = useState('');
+  const [kycBvn, setKycBvn] = useState('');
+
+  const [prefill, setPrefill] = useState<KycPrefill | null>(null);
+  const [hasKyc, setHasKyc] = useState<boolean | null>(null);
+  const [kycCredentialJwt, setKycCredentialJwt] = useState<string | null>(null);
+  const [savedProfile, setSavedProfile] = useState<OfframpProfile | null>(null);
+  const appliedSavedRef = useRef(false);
+  // Monotonic token so a slow channel load for a PREVIOUS country can't apply
+  // its result over the current one (same race fix as the withdraw screen).
+  const loadReqRef = useRef(0);
+  const [pendingNetworkId, setPendingNetworkId] = useState<string | null>(null);
+
+  const [quote, setQuote] = useState<OnrampQuoteResult | null>(null);
+  const [quoting, setQuoting] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [expandedTxId, setExpandedTxId] = useState<string | null>(null);
+  const [copied, setCopied] = useState<string | null>(null);
+
+  const isNG = kycCountry === 'NG';
+
+  // Best-effort: load the user's verified KYC identity + remembered profile
+  // (same mechanics as the withdraw screen — see comments there).
+  useEffect(() => {
+    if (!onrampEnabled || !address || !matrixRoomId) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        await awaitCompletion();
+        const mxClient = getMatrixClient();
+        if (cancelled || !mxClient) return;
+        // Waits out a still-syncing client — a one-shot read right after
+        // login can miss room state and wrongly gate a KYC'd user.
+        const owns = await waitForKycCredential(mxClient, matrixRoomId, { cancelled: () => cancelled });
+        if (cancelled) return;
+        setHasKyc(owns);
+        const saved = await loadOfframpProfile(mxClient, matrixRoomId);
+        if (!cancelled) setSavedProfile(saved);
+        if (!owns) return;
+        const result = await loadKycPrefill(mxClient, matrixRoomId);
+        if (!cancelled) setPrefill(result);
+        const jwt = await loadKycCredentialJwt(mxClient, matrixRoomId).catch(() => null);
+        if (!cancelled) setKycCredentialJwt(jwt);
+      } catch {
+        /* best-effort — leave the gate "checking" if matrix isn't reachable */
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [onrampEnabled, address, matrixRoomId, awaitCompletion, getMatrixClient]);
+
+  useEffect(() => {
+    if (!prefill) return;
+    if (prefill.name) setKycName(prefill.name);
+    if (prefill.dob) setKycDob(prefill.dob);
+    if (prefill.country) setKycCountry(prefill.country);
+    if (prefill.idType) setKycIdType(prefill.idType);
+    if (prefill.idNumber) setKycIdNumber(prefill.idNumber);
+    if (prefill.email) setKycEmail(prefill.email);
+    if (prefill.phone) setKycPhone(prefill.phone);
+  }, [prefill]);
+
+  // Apply remembered fields (once). On-ramp uses its own profile keys so the
+  // withdraw flow's bank details never leak into the deposit form.
+  useEffect(() => {
+    if (!savedProfile || appliedSavedRef.current) return;
+    appliedSavedRef.current = true;
+    if (savedProfile.onrampCountry) setCountry(savedProfile.onrampCountry);
+    if (savedProfile.onrampMethod === 'bank' || savedProfile.onrampMethod === 'momo') {
+      setPayMethod(savedProfile.onrampMethod);
+    }
+    if (savedProfile.onrampMomoNumber) setMomoNumber(savedProfile.onrampMomoNumber);
+    if (savedProfile.onrampNetworkId) setPendingNetworkId(savedProfile.onrampNetworkId);
+    if (savedProfile.bvn) setKycBvn(savedProfile.bvn);
+    // Contact / identity — only when KYC didn't provide (and lock) them.
+    if (savedProfile.name && !prefill?.name) setKycName(savedProfile.name);
+    if (savedProfile.phone && !prefill?.phone) setKycPhone(savedProfile.phone);
+    if (savedProfile.email && !prefill?.email) setKycEmail(savedProfile.email);
+    if (savedProfile.dob && !prefill?.dob) setKycDob(savedProfile.dob);
+    if (savedProfile.nationality && !prefill?.country) setKycCountry(savedProfile.nationality);
+    if (savedProfile.idType && !prefill?.idType) setKycIdType(savedProfile.idType);
+    if (savedProfile.idNumber && !prefill?.idNumber) setKycIdNumber(savedProfile.idNumber);
+  }, [savedProfile, prefill]);
+
+  // Apply the saved provider once its country's networks have loaded.
+  useEffect(() => {
+    if (!pendingNetworkId) return;
+    if (networks.some((n) => n.id === pendingNetworkId)) {
+      setNetworkId(pendingNetworkId);
+      setPendingNetworkId(null);
+    }
+  }, [pendingNetworkId, networks]);
+
+  // Supported pay-in countries — from the worker (single source of truth).
+  useEffect(() => {
+    let cancelled = false;
+    fetchSupportedCountries('onramp')
+      .then((codes) => {
+        if (!cancelled) setSupportedOptions(countryOptions(codes));
+      })
+      .catch(() => {
+        if (!cancelled) setSupportedOptions([]);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Keep the selection valid: snap an unsupported country (the default, or a
+  // stale saved one — pay-in coverage differs from payout coverage) to the
+  // first supported option.
+  useEffect(() => {
+    if (!supportedOptions.length) return;
+    if (!supportedOptions.some((o) => o.value === country)) {
+      setCountry(supportedOptions[0].value);
+    }
+  }, [supportedOptions, country]);
+
+  const loadChannels = useCallback(async () => {
+    const req = ++loadReqRef.current;
+    setLoadingChannels(true);
+    setFormError(null);
+    setNetworkId('');
+    setQuote(null);
+    setChannels([]);
+    setNetworks([]);
+    try {
+      const { channels: ch, networks: nets } = await discoverChannels(country, 'deposit');
+      if (req !== loadReqRef.current) return; // superseded by a newer country load
+      setChannels(ch.filter(isActiveDepositChannel));
+      setNetworks(nets.filter((n) => (n.status ? n.status.toLowerCase() === 'active' : true) && n.name));
+    } catch (err) {
+      if (req !== loadReqRef.current) return;
+      setFormError(err instanceof Error ? err.message : 'Failed to load payment methods');
+    } finally {
+      if (req === loadReqRef.current) setLoadingChannels(false);
+    }
+  }, [country]);
+
+  useEffect(() => {
+    if (onrampEnabled && country) void loadChannels();
+  }, [onrampEnabled, country, loadChannels]);
+
+  const isMomo = payMethod === 'momo';
+
+  // Rails this country offers for paying IN (`channels` is already filtered
+  // to active deposit channels at load time).
+  const availableMethods = useMemo<PayMethod[]>(() => {
+    const s = new Set<PayMethod>();
+    for (const c of channels) s.add(mapCategory(c.channelType));
+    return (['bank', 'momo'] as PayMethod[]).filter((m) => s.has(m));
+  }, [channels]);
+
+  // Momo providers serving this country's deposit channels. Networks are
+  // shared across ramps, so require an overlap with an active deposit channel
+  // (fall back to the rail match alone if none links up).
+  const momoNetworks = useMemo<YcNetwork[]>(() => {
+    const momoChannelIds = new Set(channels.filter((c) => mapCategory(c.channelType) === 'momo').map((c) => c.id));
+    const all = networks.filter((n) => networkMethod(n) === 'momo');
+    const linked = all.filter((n) => networkChannelIds(n).some((id) => momoChannelIds.has(id)));
+    return linked.length ? linked : all;
+  }, [networks, channels]);
+
+  const methodChannels = useMemo<YcChannel[]>(
+    () => channels.filter((c) => mapCategory(c.channelType) === payMethod),
+    [channels, payMethod],
+  );
+
+  const currency = useMemo(() => methodChannels.find((c) => c.currency)?.currency ?? '', [methodChannels]);
+  const selectedProviderName = useMemo(
+    () => networks.find((n) => n.id === networkId)?.name ?? '',
+    [networks, networkId],
+  );
+
+  // Keep the selected rail valid for the country.
+  useEffect(() => {
+    if (availableMethods.length && !availableMethods.includes(payMethod)) {
+      setPayMethod(availableMethods[0]);
+    }
+  }, [availableMethods, payMethod]);
+
+  // Drop a selected provider that doesn't serve the active rail.
+  useEffect(() => {
+    if (networkId && !momoNetworks.some((n) => n.id === networkId)) {
+      setNetworkId('');
+      setQuote(null);
+    }
+  }, [momoNetworks, networkId]);
+
+  // The quote is only valid for the exact amount + rail it was taken for.
+  const clearOnrampError = onramp.clearError;
+  useEffect(() => {
+    setQuote(null);
+    setFormError(null);
+    clearOnrampError();
+  }, [amount, currency, payMethod, clearOnrampError]);
+
+  // Once a deposit is created, clear the amount and expand the new row.
+  const activeId = onramp.active?.id;
+  useEffect(() => {
+    if (activeId) {
+      setAmount('');
+      setExpandedTxId(activeId);
+    }
+  }, [activeId]);
+
+  const transactions = onramp.transactions;
+  const hasInflightTx = transactions.some((t) => !TERMINAL_ONRAMP_STATUSES.has(t.status));
+  const refreshTransactions = onramp.refreshTransactions;
+
+  // Load history once on mount.
+  const didInitialLoadRef = useRef(false);
+  useEffect(() => {
+    if (didInitialLoadRef.current) return;
+    if (onrampEnabled && address) {
+      didInitialLoadRef.current = true;
+      void refreshTransactions().catch(() => undefined);
+    }
+  }, [onrampEnabled, address, refreshTransactions]);
+
+  // Poll the list every 10s while anything is in-flight (payment detection,
+  // conversion and the bridge all progress server-side).
+  useEffect(() => {
+    if (!hasInflightTx) return;
+    const interval = setInterval(() => void refreshTransactions().catch(() => undefined), 10000);
+    return () => clearInterval(interval);
+  }, [hasInflightTx, refreshTransactions]);
+
+  const amountNum = parseFloat(amount);
+  const showForm = Number.isFinite(amountNum) && amountNum > 0;
+
+  const limitMin = quote?.transactionLimitMin ?? null;
+  const limitMax = quote?.transactionLimitMax ?? null;
+  const belowMin = limitMin != null && Number.isFinite(amountNum) && amountNum < limitMin;
+  const aboveMax = limitMax != null && Number.isFinite(amountNum) && amountNum > limitMax;
+
+  const nameValid = kycName.trim().split(/\s+/).filter(Boolean).length >= 2;
+  const emailValid = EMAIL_RE.test(kycEmail);
+  const phoneDigits = kycPhone.replace(/\D/g, '');
+  const phoneValid = phoneDigits.length >= 7;
+  const momoDigits = momoNumber.replace(/\D/g, '');
+  const momoNumberValid = !isMomo || momoDigits.length >= 8;
+
+  const canQuote = !!currency && Number.isFinite(amountNum) && amountNum > 0;
+  const canDeposit =
+    canQuote &&
+    !!quote &&
+    // A zero estimate means fees eat the whole amount — the worker would
+    // reject the create anyway; don't let the user reach that error.
+    (quote.estimatedUsdcReceive ?? 0) > 0 &&
+    !belowMin &&
+    !aboveMax &&
+    momoNumberValid &&
+    (!isMomo || !!networkId) &&
+    nameValid &&
+    emailValid &&
+    phoneValid &&
+    !!kycDob &&
+    !!kycCountry &&
+    !!kycIdNumber &&
+    (!isNG || !!kycBvn) &&
+    !!kycCredentialJwt;
+
+  const busy = onramp.stage !== 'idle' && onramp.stage !== 'submitted' && onramp.stage !== 'error';
+
+  const locked = {
+    name: !!prefill?.name,
+    dob: !!prefill?.dob,
+    country: !!prefill?.country,
+    idType: !!prefill?.idType,
+    idNumber: !!prefill?.idNumber,
+    email: !!prefill?.email,
+    phone: !!prefill?.phone,
+  };
+  const hasPrefill = Object.values(locked).some(Boolean);
+
+  const persistProfile = useCallback(() => {
+    if (!matrixRoomId) return;
+    const mxClient = getMatrixClient();
+    if (!mxClient) return;
+    // The store is whole-blob latest-wins (no server-side merge), so spread
+    // the loaded profile first — otherwise saving deposit fields would WIPE
+    // the withdraw flow's saved bank details.
+    void saveOfframpProfile(mxClient, matrixRoomId, {
+      ...(savedProfile ?? {}),
+      onrampCountry: country,
+      onrampMethod: payMethod,
+      onrampNetworkId: networkId,
+      onrampProviderName: selectedProviderName,
+      onrampMomoNumber: momoDigits,
+      name: prefill?.name ? undefined : kycName,
+      phone: prefill?.phone ? undefined : kycPhone,
+      email: prefill?.email ? undefined : kycEmail,
+      dob: prefill?.dob ? undefined : kycDob,
+      nationality: prefill?.country ? undefined : kycCountry,
+      idType: prefill?.idType ? undefined : kycIdType,
+      idNumber: prefill?.idNumber ? undefined : kycIdNumber,
+      bvn: kycBvn,
+    });
+  }, [
+    matrixRoomId,
+    getMatrixClient,
+    savedProfile,
+    country,
+    payMethod,
+    networkId,
+    selectedProviderName,
+    momoDigits,
+    prefill,
+    kycName,
+    kycPhone,
+    kycEmail,
+    kycDob,
+    kycCountry,
+    kycIdType,
+    kycIdNumber,
+    kycBvn,
+  ]);
+
+  const onQuote = useCallback(async () => {
+    if (!canQuote) return;
+    setQuoting(true);
+    setFormError(null);
+    onramp.clearError();
+    try {
+      const q = await onramp.previewDeposit({
+        localAmount: amountNum,
+        currency,
+        channelType: payMethod,
+        country,
+      });
+      setQuote(q);
+      persistProfile();
+    } catch (err) {
+      setQuote(null);
+      setFormError(err instanceof Error ? err.message : 'Quote failed');
+    } finally {
+      setQuoting(false);
+    }
+  }, [canQuote, onramp, amountNum, currency, payMethod, country, persistProfile]);
+
+  const onDeposit = useCallback(async () => {
+    if (!canDeposit) return;
+    setFormError(null);
+    try {
+      await onramp.deposit({
+        localAmount: amountNum,
+        currency,
+        country,
+        channelType: payMethod,
+        source: {
+          accountType: payMethod,
+          ...(isMomo ? { accountNumber: `+${momoDigits}`, networkId, networkName: selectedProviderName } : {}),
+        },
+        customer: {
+          name: kycName,
+          country: kycCountry,
+          phone: `+${phoneDigits}`,
+          email: kycEmail,
+          dob: formatDob(kycDob),
+          idType: isNG ? 'NIN' : kycIdType,
+          idNumber: kycIdNumber,
+          additionalIdNumber: isNG ? kycBvn : '',
+        },
+        // Only the South African channel redirects to a hosted payment page
+        // and needs a return URL — YC rejects it as required there, and other
+        // channels haven't been verified to accept the field.
+        returnUrl:
+          country === 'ZA' && typeof window !== 'undefined' ? `${window.location.origin}/profile/onramp` : undefined,
+        kycCredential: kycCredentialJwt ?? '',
+      });
+      persistProfile();
+    } catch {
+      /* surfaced via onramp.error */
+    }
+  }, [
+    canDeposit,
+    onramp,
+    amountNum,
+    currency,
+    country,
+    payMethod,
+    isMomo,
+    momoDigits,
+    networkId,
+    selectedProviderName,
+    kycName,
+    kycCountry,
+    phoneDigits,
+    kycEmail,
+    kycDob,
+    isNG,
+    kycIdType,
+    kycIdNumber,
+    kycBvn,
+    kycCredentialJwt,
+    persistProfile,
+  ]);
+
+  const copyToClipboard = useCallback((key: string, value: string) => {
+    void navigator.clipboard?.writeText(value).then(() => {
+      setCopied(key);
+      setTimeout(() => setCopied((cur) => (cur === key ? null : cur)), 2000);
+    });
+  }, []);
+
+  return (
+    <div className={styles.page}>
+      <Header onGradient title='Deposit' onBack={() => router.push('/profile')} />
+
+      <div className={styles.headerBand} />
+
+      <main className={styles.body}>
+        {!onrampEnabled && <div className={styles.alertInfo}>Deposits aren’t available on this network.</div>}
+
+        {onrampEnabled && (
+          <>
+            {hasKyc === null && (
+              <div className={styles.card}>
+                <div className={styles.balanceRow}>
+                  <Loader size={16} />
+                  <span className={styles.balanceUnit}>Checking your verification…</span>
+                </div>
+              </div>
+            )}
+
+            {hasKyc === false && (
+              <div className={styles.card}>
+                <p className={styles.cardTitle}>Verify your identity first</p>
+                <p className={styles.kycGateText}>
+                  You need to complete identity verification (KYC) before you can deposit. Check your verification
+                  status on your profile.
+                </p>
+                <div className={styles.actions}>
+                  <Button
+                    label='View verification status'
+                    size={BUTTON_SIZE.mediumLarge}
+                    bgColor={BUTTON_BG_COLOR.primary}
+                    borderColor={BUTTON_BORDER_COLOR.primary}
+                    color={BUTTON_COLOR.white}
+                    onClick={() => router.push('/profile')}
+                  />
+                </div>
+              </div>
+            )}
+
+            {hasKyc === true && (
+              <>
+                {/* Deposit form */}
+                <div className={styles.card}>
+                  <p className={styles.cardTitle}>Buy USDC</p>
+
+                  <div className={styles.row}>
+                    <div className={styles.field}>
+                      <label className={styles.label}>You pay{currency ? ` (${currency})` : ''}</label>
+                      <input
+                        className={`${styles.input}${belowMin || aboveMax ? ` ${styles.inputError}` : ''}`}
+                        type='number'
+                        inputMode='decimal'
+                        min={0}
+                        placeholder='0.00'
+                        value={amount}
+                        onChange={(e) => setAmount(e.currentTarget.value)}
+                      />
+                    </div>
+                    <div className={styles.field}>
+                      <label className={styles.label}>Country</label>
+                      <select
+                        className={styles.select}
+                        value={country}
+                        onChange={(e) => setCountry(e.currentTarget.value)}
+                      >
+                        {supportedOptions.map((o) => (
+                          <option key={o.value} value={o.value}>
+                            {o.label}
+                          </option>
+                        ))}
+                      </select>
+                    </div>
+                  </div>
+
+                  <div className={`${styles.collapse}${showForm ? ` ${styles.collapseOpen}` : ''}`}>
+                    <div className={styles.collapseInner}>
+                      {availableMethods.length > 1 && (
+                        <div className={styles.row}>
+                          <div className={styles.field}>
+                            <label className={styles.label}>Payment method</label>
+                            <select
+                              className={styles.select}
+                              value={payMethod}
+                              onChange={(e) => {
+                                setPayMethod(e.currentTarget.value as PayMethod);
+                                setNetworkId('');
+                                setQuote(null);
+                              }}
+                            >
+                              {availableMethods.map((m) => (
+                                <option key={m} value={m}>
+                                  {PAY_METHOD_LABEL[m]}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                        </div>
+                      )}
+
+                      {loadingChannels && (
+                        <div className={styles.balanceRow}>
+                          <Loader size={16} />
+                          <span className={styles.balanceUnit}>Loading payment methods…</span>
+                        </div>
+                      )}
+
+                      {!loadingChannels && channels.length === 0 && (
+                        <span className={styles.warnLine}>No payment methods available for this country.</span>
+                      )}
+
+                      {isMomo && (
+                        <div className={styles.row}>
+                          <div className={styles.field}>
+                            <label className={styles.label}>Mobile provider</label>
+                            <select
+                              className={styles.select}
+                              value={networkId}
+                              disabled={loadingChannels || momoNetworks.length === 0}
+                              onChange={(e) => {
+                                setNetworkId(e.currentTarget.value);
+                                setQuote(null);
+                              }}
+                            >
+                              <option value=''>
+                                {loadingChannels
+                                  ? 'Loading…'
+                                  : momoNetworks.length
+                                  ? 'Select your provider'
+                                  : 'No providers for this country'}
+                              </option>
+                              {momoNetworks.map((n) => (
+                                <option key={n.id} value={n.id}>
+                                  {networkLabel(n)}
+                                </option>
+                              ))}
+                            </select>
+                          </div>
+                          <div className={styles.field}>
+                            <label className={styles.label}>Your mobile money number</label>
+                            <div
+                              className={`${styles.inputPrefixWrap}${
+                                momoNumber && !momoNumberValid ? ` ${styles.inputError}` : ''
+                              }`}
+                            >
+                              <span className={styles.inputPrefix}>+</span>
+                              <input
+                                className={styles.bareInput}
+                                inputMode='numeric'
+                                placeholder='254712345678'
+                                value={momoDigits}
+                                onChange={(e) => setMomoNumber(e.currentTarget.value.replace(/[^\d]/g, ''))}
+                              />
+                            </div>
+                            {momoNumber && !momoNumberValid && (
+                              <span className={styles.errorText}>Enter the full number with country code</span>
+                            )}
+                            <span className={styles.hint}>You’ll approve the payment on this phone.</span>
+                          </div>
+                        </div>
+                      )}
+
+                      {!isMomo && !loadingChannels && channels.length > 0 && (
+                        <span className={styles.hint}>
+                          {country === 'ZA'
+                            ? 'You’ll be sent to a secure payment page to complete the transfer.'
+                            : 'You’ll get the bank account and reference to pay after you continue.'}
+                        </span>
+                      )}
+
+                      <div className={styles.divider}>
+                        <span className={styles.dividerLabel}>
+                          Your details (KYC){hasPrefill && <InfoIcon label={KYC_INFO_LABEL} />}
+                        </span>
+                      </div>
+
+                      <div className={styles.row}>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Full name{locked.name && <PrefilledMark />}</label>
+                          <input
+                            className={`${styles.input}${kycName && !nameValid ? ` ${styles.inputError}` : ''}`}
+                            placeholder='First Last'
+                            value={kycName}
+                            readOnly={locked.name}
+                            onChange={(e) => setKycName(e.currentTarget.value)}
+                          />
+                          {kycName && !nameValid && <span className={styles.errorText}>Enter first and last name</span>}
+                        </div>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Email{locked.email && <PrefilledMark />}</label>
+                          <input
+                            className={`${styles.input}${kycEmail && !emailValid ? ` ${styles.inputError}` : ''}`}
+                            type='email'
+                            value={kycEmail}
+                            readOnly={locked.email}
+                            onChange={(e) => setKycEmail(e.currentTarget.value)}
+                          />
+                          {kycEmail && !emailValid && <span className={styles.errorText}>Invalid email</span>}
+                        </div>
+                      </div>
+
+                      <div className={styles.row}>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Phone{locked.phone && <PrefilledMark />}</label>
+                          <div
+                            className={`${styles.inputPrefixWrap}${
+                              kycPhone && !phoneValid ? ` ${styles.inputError}` : ''
+                            }${locked.phone ? ` ${styles.lockedWrap}` : ''}`}
+                          >
+                            <span className={styles.inputPrefix}>+</span>
+                            <input
+                              className={styles.bareInput}
+                              inputMode='numeric'
+                              placeholder='27821234567'
+                              value={kycPhone}
+                              readOnly={locked.phone}
+                              onChange={(e) => setKycPhone(e.currentTarget.value.replace(/[^\d]/g, ''))}
+                            />
+                          </div>
+                          {kycPhone && !phoneValid && (
+                            <span className={styles.errorText}>Enter full international number</span>
+                          )}
+                        </div>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Date of birth{locked.dob && <PrefilledMark />}</label>
+                          <input
+                            className={styles.input}
+                            type='date'
+                            max={new Date().toISOString().slice(0, 10)}
+                            value={kycDob}
+                            readOnly={locked.dob}
+                            onChange={(e) => setKycDob(e.currentTarget.value)}
+                          />
+                        </div>
+                      </div>
+
+                      <div className={styles.row}>
+                        <div className={styles.field}>
+                          <label className={styles.label}>Your country{locked.country && <PrefilledMark />}</label>
+                          <select
+                            className={styles.select}
+                            value={kycCountry}
+                            disabled={locked.country}
+                            onChange={(e) => setKycCountry(e.currentTarget.value)}
+                          >
+                            {ALL_COUNTRY_OPTIONS.map((o) => (
+                              <option key={o.value} value={o.value}>
+                                {o.label}
+                              </option>
+                            ))}
+                          </select>
+                        </div>
+                        <div className={styles.field}>
+                          <label className={styles.label}>ID type{!isNG && locked.idType && <PrefilledMark />}</label>
+                          {isNG ? (
+                            <input className={styles.input} value='NIN' readOnly />
+                          ) : (
+                            <select
+                              className={styles.select}
+                              value={kycIdType}
+                              disabled={locked.idType}
+                              onChange={(e) => setKycIdType(e.currentTarget.value)}
+                            >
+                              {ID_TYPE_OPTIONS.map((o) => (
+                                <option key={o.value} value={o.value}>
+                                  {o.label}
+                                </option>
+                              ))}
+                            </select>
+                          )}
+                        </div>
+                      </div>
+
+                      <div className={styles.row}>
+                        <div className={styles.field}>
+                          <label className={styles.label}>
+                            {isNG ? 'NIN' : 'ID number'}
+                            {locked.idNumber && <PrefilledMark />}
+                          </label>
+                          <input
+                            className={styles.input}
+                            value={kycIdNumber}
+                            readOnly={locked.idNumber}
+                            onChange={(e) => setKycIdNumber(e.currentTarget.value)}
+                          />
+                        </div>
+                        {isNG && (
+                          <div className={styles.field}>
+                            <label className={styles.label}>BVN</label>
+                            <input
+                              className={styles.input}
+                              value={kycBvn}
+                              onChange={(e) => setKycBvn(e.currentTarget.value)}
+                            />
+                          </div>
+                        )}
+                      </div>
+
+                      {quote && (
+                        <div className={`${styles.quote}${belowMin || aboveMax ? ` ${styles.quoteWarn}` : ''}`}>
+                          <span className={styles.quoteMain}>
+                            You receive ~{quote.estimatedUsdcReceive ?? '?'} USDC
+                            <InfoIcon label={ESTIMATE_NOTE} />
+                          </span>
+                          {quote.rateLocal != null && (
+                            <span className={styles.hint}>
+                              1 USDC ≈ {quote.rateLocal} {currency} · fees ~$
+                              {(
+                                (quote.serviceFeeUSD ?? 0) +
+                                (quote.partnerFeeUSD ?? 0) +
+                                (quote.networkFeeUSDEstimate ?? 0) +
+                                (quote.bridgeFeeUsd ?? 0)
+                              ).toFixed(2)}
+                            </span>
+                          )}
+                          {(quote.estimatedUsdcReceive ?? 0) <= 0 && (
+                            <span className={styles.warnLine}>
+                              This amount is too small — fees would use it all up. Increase the amount.
+                            </span>
+                          )}
+                          {belowMin && limitMin != null && (
+                            <span className={styles.warnLine}>
+                              Below the {limitMin} {currency} minimum — increase the amount.
+                            </span>
+                          )}
+                          {aboveMax && limitMax != null && (
+                            <span className={styles.warnLine}>
+                              Above the {limitMax} {currency} maximum — reduce the amount.
+                            </span>
+                          )}
+                        </div>
+                      )}
+
+                      <div className={styles.actions}>
+                        {quote ? (
+                          <Button
+                            label={busy ? 'Creating…' : 'Continue'}
+                            size={BUTTON_SIZE.mediumLarge}
+                            bgColor={BUTTON_BG_COLOR.primary}
+                            borderColor={BUTTON_BORDER_COLOR.primary}
+                            color={BUTTON_COLOR.white}
+                            disabled={!canDeposit || busy}
+                            onClick={onDeposit}
+                          />
+                        ) : (
+                          <Button
+                            label={quoting ? 'Getting quote…' : 'Get quote'}
+                            size={BUTTON_SIZE.mediumLarge}
+                            bgColor={BUTTON_BG_COLOR.primary}
+                            borderColor={BUTTON_BORDER_COLOR.primary}
+                            color={BUTTON_COLOR.white}
+                            disabled={!canQuote || quoting}
+                            onClick={onQuote}
+                          />
+                        )}
+                      </div>
+                    </div>
+                  </div>
+
+                  {(formError || onramp.error) && <div className={styles.alertError}>{formError || onramp.error}</div>}
+                </div>
+
+                {/* History — instructions for in-flight deposits live here too */}
+                {transactions.length > 0 && (
+                  <div className={styles.card}>
+                    <div className={styles.historyHeader}>
+                      <p className={styles.cardTitle} style={{ margin: 0 }}>
+                        Your deposits
+                      </p>
+                      <button
+                        type='button'
+                        className={styles.iconButton}
+                        aria-label='Refresh deposits'
+                        onClick={() => void refreshTransactions().catch(() => undefined)}
+                      >
+                        <svg
+                          width={16}
+                          height={16}
+                          viewBox='0 0 24 24'
+                          fill='none'
+                          stroke='currentColor'
+                          strokeWidth='2'
+                          strokeLinecap='round'
+                          strokeLinejoin='round'
+                        >
+                          <polyline points='23 4 23 10 17 10' />
+                          <polyline points='1 20 1 14 7 14' />
+                          <path d='M3.51 9a9 9 0 0 1 14.85-3.36L23 10M1 14l4.64 4.36A9 9 0 0 0 20.49 15' />
+                        </svg>
+                      </button>
+                    </div>
+
+                    {transactions.map((tx) => {
+                      const expanded = expandedTxId === tx.id;
+                      const isTerminal = TERMINAL_ONRAMP_STATUSES.has(tx.status);
+                      const good = tx.status === 'delivered' || tx.status === 'refunded';
+                      const awaitingPayment = AWAITING_PAYMENT_STATUSES.has(tx.status);
+                      const expired = tx.expires_at != null && tx.expires_at * 1000 < Date.now();
+                      const txMomo = (tx.channel_type ?? '').toLowerCase() === 'momo';
+                      const bankInfo = tx.bank_info ?? {};
+                      const statusClass = isTerminal
+                        ? good
+                          ? styles.statusGreen
+                          : styles.statusRed
+                        : styles.statusBlue;
+                      return (
+                        <div key={tx.id} className={styles.txCard}>
+                          <button className={styles.txHead} onClick={() => setExpandedTxId(expanded ? null : tx.id)}>
+                            <span>
+                              <span className={styles.txTitle}>
+                                {tx.local_amount ?? '?'} {tx.currency ?? ''} →{' '}
+                                {tx.net_usdc != null ? formatUsdc(tx.net_usdc) : '?'} USDC
+                              </span>
+                              <br />
+                              <span className={styles.txSub}>
+                                {new Date(tx.created_at * 1000).toLocaleString()} ·{' '}
+                                {txMomo ? 'Mobile money' : 'Bank transfer'}
+                              </span>
+                            </span>
+                            <span className={`${styles.txStatus} ${statusClass}`}>{statusLabel(tx.status)}</span>
+                          </button>
+
+                          {/* Payment instructions — shown while YC awaits the user's fiat */}
+                          {awaitingPayment && !expired && (
+                            <div className={styles.txDetail}>
+                              {txMomo ? (
+                                <span className={styles.hint}>
+                                  Approve the payment request sent to your phone
+                                  {(tx.source as { accountNumber?: string })?.accountNumber
+                                    ? ` (${(tx.source as { accountNumber?: string }).accountNumber})`
+                                    : ''}
+                                  .
+                                </span>
+                              ) : tx.payment_link ? (
+                                <>
+                                  <span className={styles.hint}>
+                                    Complete your payment of{' '}
+                                    <strong>
+                                      {tx.local_amount ?? '?'} {tx.currency ?? ''}
+                                    </strong>{' '}
+                                    on the secure payment page.
+                                  </span>
+                                  <div className={styles.actions}>
+                                    <Button
+                                      label='Open payment page'
+                                      size={BUTTON_SIZE.small}
+                                      bgColor={BUTTON_BG_COLOR.primary}
+                                      borderColor={BUTTON_BORDER_COLOR.primary}
+                                      color={BUTTON_COLOR.white}
+                                      onClick={() => window.open(tx.payment_link ?? '', '_blank', 'noopener')}
+                                    />
+                                  </div>
+                                </>
+                              ) : (
+                                <>
+                                  <span className={styles.hint}>
+                                    Transfer exactly{' '}
+                                    <strong>
+                                      {tx.local_amount ?? '?'} {tx.currency ?? ''}
+                                    </strong>{' '}
+                                    to this account{tx.reference ? ' and include the reference' : ''}:
+                                  </span>
+                                  {bankInfo.name && (
+                                    <div className={styles.detailRow}>
+                                      <span>Bank</span>
+                                      <span className={styles.detailVal}>{bankInfo.name}</span>
+                                    </div>
+                                  )}
+                                  {bankInfo.accountName && (
+                                    <div className={styles.detailRow}>
+                                      <span>Account name</span>
+                                      <span className={styles.detailVal}>{bankInfo.accountName}</span>
+                                    </div>
+                                  )}
+                                  {bankInfo.accountNumber && (
+                                    <div className={styles.detailRow}>
+                                      <span>Account number</span>
+                                      <span className={styles.detailVal} style={{ fontFamily: 'monospace' }}>
+                                        {bankInfo.accountNumber}{' '}
+                                        <button
+                                          type='button'
+                                          className={styles.iconButton}
+                                          aria-label='Copy account number'
+                                          onClick={() => copyToClipboard(`${tx.id}-acc`, bankInfo.accountNumber ?? '')}
+                                        >
+                                          {copied === `${tx.id}-acc` ? '✓' : '⧉'}
+                                        </button>
+                                      </span>
+                                    </div>
+                                  )}
+                                  {tx.reference && (
+                                    <div className={styles.detailRow}>
+                                      <span>Reference</span>
+                                      <span className={styles.detailVal} style={{ fontFamily: 'monospace' }}>
+                                        {tx.reference}{' '}
+                                        <button
+                                          type='button'
+                                          className={styles.iconButton}
+                                          aria-label='Copy reference'
+                                          onClick={() => copyToClipboard(`${tx.id}-ref`, tx.reference ?? '')}
+                                        >
+                                          {copied === `${tx.id}-ref` ? '✓' : '⧉'}
+                                        </button>
+                                      </span>
+                                    </div>
+                                  )}
+                                </>
+                              )}
+                              {tx.net_usdc != null && (
+                                <span className={styles.hint}>
+                                  You’ll receive <strong>~{formatUsdc(tx.net_usdc)} USDC</strong> on your ixo account.
+                                </span>
+                              )}
+                              {tx.expires_at != null && (
+                                <span className={styles.warnLine}>
+                                  Pay before {new Date(tx.expires_at * 1000).toLocaleTimeString()} — the rate expires.
+                                </span>
+                              )}
+                            </div>
+                          )}
+
+                          {expanded && (
+                            <div className={styles.txDetail}>
+                              <div className={styles.detailRow}>
+                                <span>You pay</span>
+                                <span className={styles.detailVal}>
+                                  {tx.local_amount ?? '?'} {tx.currency ?? ''}
+                                </span>
+                              </div>
+                              {tx.rate != null && (
+                                <div className={styles.detailRow}>
+                                  <span>Rate</span>
+                                  <span className={styles.detailVal}>
+                                    1 USDC ≈ {tx.rate} {tx.currency ?? ''}
+                                  </span>
+                                </div>
+                              )}
+                              <div className={styles.detailRow}>
+                                <span>YellowCard fees</span>
+                                <span className={styles.detailVal}>
+                                  ~$
+                                  {(
+                                    (tx.service_fee_usd ?? 0) +
+                                    (tx.network_fee_usd ?? 0) +
+                                    (tx.partner_fee_usd ?? 0)
+                                  ).toFixed(2)}
+                                </span>
+                              </div>
+                              {tx.bridge_fee_usd != null && (
+                                <div className={styles.detailRow}>
+                                  <span>Delivery fee</span>
+                                  <span className={styles.detailVal}>~${tx.bridge_fee_usd.toFixed(2)}</span>
+                                </div>
+                              )}
+                              <div className={styles.detailRow}>
+                                <span>You receive</span>
+                                <span className={styles.detailVal} style={{ fontWeight: 600 }}>
+                                  {tx.net_usdc != null ? formatUsdc(tx.net_usdc) : '?'} USDC
+                                </span>
+                              </div>
+                              <div className={styles.detailRow}>
+                                <span>Status</span>
+                                <span className={styles.detailVal} style={{ textTransform: 'capitalize' }}>
+                                  {statusLabel(tx.status)}
+                                </span>
+                              </div>
+                              {tx.status === 'bridge_failed' && (
+                                <span className={styles.warnLine}>
+                                  Your payment was received but the delivery to your ixo account needs attention —
+                                  support has been notified and will complete it.
+                                </span>
+                              )}
+                              {tx.error && tx.status !== 'bridge_failed' && (
+                                <span className={styles.errorText}>Error: {tx.error_detail ?? tx.error}</span>
+                              )}
+                              {tx.yc_collection_id && (
+                                <div className={styles.detailRow}>
+                                  <span>YellowCard collection ID</span>
+                                  <span className={styles.detailVal} style={{ fontFamily: 'monospace' }}>
+                                    {tx.yc_collection_id}
+                                  </span>
+                                </div>
+                              )}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
+              </>
+            )}
+          </>
+        )}
+      </main>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Inline info marker — same tap-friendly tooltip as the withdraw screen.
+// ---------------------------------------------------------------------------
+
+function InfoMark({ children, label, markClassName }: { children: ReactNode; label: string; markClassName: string }) {
+  const ref = useRef<HTMLButtonElement>(null);
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  const toggle = () =>
+    setPos((cur) => {
+      if (cur) return null;
+      const r = ref.current?.getBoundingClientRect();
+      if (!r) return null;
+      return { top: r.bottom + 6, left: Math.max(8, Math.min(r.left, window.innerWidth - 232)) };
+    });
+
+  useEffect(() => {
+    if (!pos) return;
+    const close = () => setPos(null);
+    window.addEventListener('scroll', close, true);
+    window.addEventListener('resize', close);
+    return () => {
+      window.removeEventListener('scroll', close, true);
+      window.removeEventListener('resize', close);
+    };
+  }, [pos]);
+
+  return (
+    <>
+      <button
+        ref={ref}
+        type='button'
+        className={markClassName}
+        aria-label={label}
+        title={label}
+        onClick={toggle}
+        onBlur={() => setPos(null)}
+      >
+        {children}
+      </button>
+      {pos &&
+        typeof document !== 'undefined' &&
+        createPortal(
+          <span className={styles.infoBubble} style={{ top: pos.top, left: pos.left }} role='tooltip'>
+            {label}
+          </span>,
+          document.body,
+        )}
+    </>
+  );
+}
+
+function PrefilledMark() {
+  return (
+    <InfoMark label={VERIFIED_LABEL} markClassName={styles.asteriskMark}>
+      *
+    </InfoMark>
+  );
+}
+
+function InfoIcon({ label }: { label: string }) {
+  return (
+    <InfoMark label={label} markClassName={styles.infoMark}>
+      <svg
+        width={14}
+        height={14}
+        viewBox='0 0 24 24'
+        fill='none'
+        stroke='currentColor'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      >
+        <circle cx='12' cy='12' r='10' />
+        <line x1='12' y1='16' x2='12' y2='12' />
+        <line x1='12' y1='8' x2='12.01' y2='8' />
+      </svg>
+    </InfoMark>
+  );
+}

--- a/screens/profile.tsx
+++ b/screens/profile.tsx
@@ -180,6 +180,42 @@ export default function ProfileScreen() {
         </h3>
 
         <button
+          onClick={() => router.push('/profile/onramp')}
+          style={{
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+            width: '100%',
+            padding: '16px',
+            marginBottom: '8px',
+            border: 'none',
+            borderRadius: 'var(--card-border-radius)',
+            background: 'var(--background-color, #fff)',
+            cursor: 'pointer',
+            color: 'var(--text-primary)',
+          }}
+        >
+          <span style={{ display: 'flex', flexDirection: 'column', alignItems: 'flex-start', gap: 2 }}>
+            <span style={{ fontWeight: 500 }}>Deposit</span>
+            <span style={{ fontSize: '0.78rem', color: 'var(--text-secondary)' }}>
+              Buy USDC with local money via YellowCard
+            </span>
+          </span>
+          <svg
+            width={20}
+            height={20}
+            viewBox='0 0 24 24'
+            fill='none'
+            stroke='currentColor'
+            strokeWidth='2'
+            strokeLinecap='round'
+            strokeLinejoin='round'
+          >
+            <polyline points='9 18 15 12 9 6' />
+          </svg>
+        </button>
+
+        <button
           onClick={() => router.push('/profile/offramp')}
           style={{
             display: 'flex',

--- a/utils/kycPrefill.ts
+++ b/utils/kycPrefill.ts
@@ -16,6 +16,30 @@ export function hasKycCredential(mxClient: MxClient, roomId: string): boolean {
 }
 
 /**
+ * `hasKycCredential`, but tolerant of the matrix client still syncing: the
+ * index lives in room STATE, which may not be loaded yet right after login
+ * (especially a fresh device/session). A one-shot read at that moment would
+ * wrongly gate a fully-KYC'd user, so poll until the credential appears or the
+ * timeout elapses. Resolves `true` as soon as it's found; `false` only after
+ * the full window passed with the room state available-but-empty.
+ */
+export async function waitForKycCredential(
+  mxClient: MxClient,
+  roomId: string,
+  opts: { timeoutMs?: number; pollIntervalMs?: number; cancelled?: () => boolean } = {},
+): Promise<boolean> {
+  const timeoutMs = opts.timeoutMs ?? 15000;
+  const pollIntervalMs = opts.pollIntervalMs ?? 500;
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    if (opts.cancelled?.()) return false;
+    if (hasKycCredential(mxClient, roomId)) return true;
+    if (Date.now() >= deadline) return false;
+    await new Promise((r) => setTimeout(r, pollIntervalMs));
+  }
+}
+
+/**
  * Best-effort auto-fill for the off-ramp KYC form from the user's stored identity.
  *
  * Design: each SOURCE declares its own `fields` map — exactly which keys (or a
@@ -191,7 +215,11 @@ export const KYC_SOURCES: KycSource[] = [
     // suffix) is the street number here, NOT an ID — only `identifier_1` is the
     // identity-document number.
     fields: {
-      name: composeName(['givenName', 'given_name', 'first_name'], ['familyName', 'family_name', 'last_name', 'surname'], ['name', 'full_name']),
+      name: composeName(
+        ['givenName', 'given_name', 'first_name'],
+        ['familyName', 'family_name', 'last_name', 'surname'],
+        ['name', 'full_name'],
+      ),
       dob: ['birthDate', 'birth_date', 'date_of_birth', 'dob'],
       country: ['nationality', 'country', 'birth_country'],
       idType: ['document_type', 'id_type'],

--- a/utils/offrampProfile.ts
+++ b/utils/offrampProfile.ts
@@ -37,6 +37,14 @@ export interface OfframpProfile {
   idType?: string;
   idNumber?: string;
   bvn?: string;
+  /** On-ramp (deposit) fields — same store, separate keys so the two flows
+   *  never overwrite each other's rail/provider choices. */
+  onrampCountry?: string;
+  onrampMethod?: string;
+  onrampNetworkId?: string;
+  onrampProviderName?: string;
+  /** Momo number the user pays FROM (digits, international format). */
+  onrampMomoNumber?: string;
 }
 
 /** Best-effort read of the saved profile; null on absence / decryption failure. */

--- a/utils/ucanYellowcard.ts
+++ b/utils/ucanYellowcard.ts
@@ -1,4 +1,10 @@
-import { createInvocation, serializeInvocation, signerFromMnemonic, type Capability, type SupportedDID } from '@ixo/ucan';
+import {
+  createInvocation,
+  serializeInvocation,
+  signerFromMnemonic,
+  type Capability,
+  type SupportedDID,
+} from '@ixo/ucan';
 
 import authConstants from '@constants/auth';
 import { YELLOWCARD_WORKER_API } from '@constants/yellowcard';
@@ -48,11 +54,9 @@ function generateNonce(): string {
 
 const OFFRAMP_CAPABILITY: Capability = { can: 'yellowcard/offramp', with: 'ixo:yellowcard' };
 
-/**
- * Mint a fresh single-use invocation CAR (bearer token) for the off-ramp
- * capability, signed by the user's Ed25519 key.
- */
-export async function mintOfframpBearer(userDid: string): Promise<string> {
+const ONRAMP_CAPABILITY: Capability = { can: 'yellowcard/onramp', with: 'ixo:yellowcard' };
+
+async function mintBearer(userDid: string, capability: Capability): Promise<string> {
   const mnemonic = secureLoad(authConstants.secretKey.ED_SIGNING_MNEMONIC);
   if (!mnemonic) throw new Error('Signing mnemonic not available — please sign in again');
 
@@ -62,10 +66,23 @@ export async function mintOfframpBearer(userDid: string): Promise<string> {
   const invocation = await createInvocation({
     issuer: signer,
     audience: workerDid,
-    capability: OFFRAMP_CAPABILITY,
+    capability,
     expiration: Math.floor(Date.now() / 1000) + 300,
     facts: [{ nonce: generateNonce() }],
   });
 
   return serializeInvocation(invocation);
+}
+
+/**
+ * Mint a fresh single-use invocation CAR (bearer token) for the off-ramp
+ * capability, signed by the user's Ed25519 key.
+ */
+export function mintOfframpBearer(userDid: string): Promise<string> {
+  return mintBearer(userDid, OFFRAMP_CAPABILITY);
+}
+
+/** Same, for the on-ramp capability. */
+export function mintOnrampBearer(userDid: string): Promise<string> {
+  return mintBearer(userDid, ONRAMP_CAPABILITY);
 }


### PR DESCRIPTION
## What

Adds the **deposit (on-ramp)** flow next to the existing withdraw flow: pick a country + payment method, get a live quote, pay local fiat (momo prompt / bank transfer + reference / hosted payment link), and receive USDC on your ixo account. The worker owns settlement and bridging — no client-side signing.

Worker counterpart: ixoworld/yellowcard-worker#7

## Included

- `screens/onramp.tsx`, `pages/profile/onramp.tsx`, Deposit button on the profile screen — quote with positive-estimate gate, KYC prefill locks, payment instructions with copy buttons and YC's real `expiresAt` deadline, history with 10s polling.
- `hooks/useOnramp.ts` — quote/create/list/poll against the worker `/onramp` API; `utils/ucanYellowcard.ts` mints the `yellowcard/onramp` bearer.
- Client-side active-deposit-channel filter + snap-to-supported-country guard.
- Profile saves now **merge** the loaded Matrix profile blob in BOTH flows (the whole-blob latest-wins store meant deposit/withdraw could wipe each other's saved fields).
- `waitForKycCredential()` fixes the "Verify your identity first" false negative when the gate raced the initial Matrix sync.

## Verified

Live mainnet run end-to-end through this UI: 117 ZMW paid via the deposit screen → 5.749999 USDC delivered to the account. Typecheck + lint clean.

Authored by: Michael Pretorius <michael@ixo.world>
