### PR TITLE
feat: Yoma deep-link return + DID↔Yoma account link flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,8 @@ NEXT_PUBLIC_MATRIX_ROOM_BOT_URL=""
 
 # ixo-yoma-jambo-worker base URL (enables subclaim bottom-sheet feature when set)
 NEXT_PUBLIC_JAMBO_WORKER_URL=""
+# Yoma pull-synchronisation worker (partner API) — hosts the DID<->Yoma link endpoints.
+NEXT_PUBLIC_YOMA_SYNC_WORKER_URL=""
 
 # ixo email-notifier worker base URL (enables the Email Notifications section on
 # the settings page when set; leave blank to hide the feature). Deployments:

--- a/components/AuthGuard.tsx
+++ b/components/AuthGuard.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 import { useRouter } from 'next/router';
 import { useAuth } from '@hooks/useAuth';
+import { saveReturnTo } from '@utils/returnTo';
 import GradientBand from '@components/GradientBand/GradientBand';
 import { GRADIENT_COLORS } from '@constants/gradientColors';
 
@@ -9,11 +10,18 @@ export default function AuthGuard({ children }: { children: React.ReactNode }) {
   const router = useRouter();
 
   useEffect(() => {
+    // On statically-optimized dynamic routes, router.asPath is the literal
+    // pattern ("/entities/[entityId]") until hydration completes — wait for
+    // isReady so we save the real URL, not the placeholder.
+    if (!router.isReady) return;
     if (!isLoading && !isLoggedIn) {
+      // Remember the deep link (e.g. a Yoma hand-off to /entities/<did>) so
+      // the auth callback can land the user back here instead of home.
+      saveReturnTo(router.asPath);
       router.replace('/auth');
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isLoading, isLoggedIn]);
+  }, [isLoading, isLoggedIn, router.isReady]);
 
   if (isLoading) {
     return (

--- a/constants/auth.ts
+++ b/constants/auth.ts
@@ -9,6 +9,7 @@ const authConstants = {
     MATRIX_USER_ID: 'auth_ixo_matrix_user_id',
     MATRIX_ROOM_ID: 'auth_ixo_matrix_room_id',
     DISPLAY_NAME: 'auth_ixo_display_name',
+    EMAIL: 'auth_ixo_email',
     SESSION_CREATED_AT: 'auth_ixo_session_created_at',
   },
 };

--- a/contexts/auth.ts
+++ b/contexts/auth.ts
@@ -8,12 +8,15 @@ export interface AuthContextType {
   address: string | null;
   did: string | null;
   displayName: string | null;
+  /** Auth-hub email (display only); null for sessions from before the hub returned it. */
+  email: string | null;
   sessionAuthenticatorId: string | null;
   matrixUserId: string | null;
   matrixRoomId: string | null;
   loginWithAuthHub: (data: AuthHubSessionData) => void;
   onSign: (messages: any[]) => Promise<DeliverTxResponse>;
-  logout: () => Promise<void>;
+  /** `preserveReturnTo` = "switch account": keep the deep link + Yoma hand-off marker. */
+  logout: (options?: { preserveReturnTo?: boolean }) => Promise<void>;
 }
 
 export const AuthContext = createContext<AuthContextType>({
@@ -22,6 +25,7 @@ export const AuthContext = createContext<AuthContextType>({
   address: null,
   did: null,
   displayName: null,
+  email: null,
   sessionAuthenticatorId: null,
   matrixUserId: null,
   matrixRoomId: null,

--- a/lib/authHub/devBypass.ts
+++ b/lib/authHub/devBypass.ts
@@ -14,6 +14,7 @@ export function getDevBypassSession(): AuthHubSessionData {
     address: 'ixo1devbypassaddress000000000000000000000',
     did: 'did:ixo:entity:devbypass000000000000000000000',
     displayName: 'Dev User',
+    email: 'devbypass@example.com',
     sessionMnemonic:
       'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about',
     sessionAuthenticatorId: '1',

--- a/lib/authHub/redirect.ts
+++ b/lib/authHub/redirect.ts
@@ -4,6 +4,12 @@ export interface AuthHubSessionData {
   address: string;
   did: string;
   displayName: string | null;
+  /**
+   * The user's WorkOS-verified email (nullable; absent from hubs that predate
+   * the field). Display/UX only — the Yoma link flow never trusts it, the
+   * yoma worker verifies the email itself against the hub via UCAN.
+   */
+  email?: string | null;
   sessionMnemonic: string | null;
   sessionAuthenticatorId: string | null;
   edSigningMnemonic: string | null;

--- a/lib/yomaSync/client.ts
+++ b/lib/yomaSync/client.ts
@@ -1,0 +1,104 @@
+import { createInvocation, serializeInvocation, signerFromMnemonic, type SupportedDID } from '@ixo/ucan';
+
+import authConstants from '@constants/auth';
+import { secureLoad } from '@utils/storage';
+import { mintDelegation } from '@utils/ucanDelegation';
+import { YOMA_SYNC_API_BASE } from './config';
+
+/**
+ * Client for the yoma worker's DID ↔ Yoma link endpoints.
+ *
+ * Auth follows the KYC/notifier pattern: a short-lived UCAN invocation
+ * (`yoma/link` on `ixo:yoma`) authenticates the call, and the bind endpoint
+ * additionally carries an `auth/user/email` delegation the worker forwards to
+ * the auth hub — the hub's answer (not anything this client sends) decides
+ * the linked email. Failures are soft everywhere: the flow retries next
+ * session, it must never disturb the user.
+ */
+
+export interface YomaLinkResult {
+  email: string | null;
+  yomaId: string | null;
+}
+
+const EMAIL_DELEGATION_TTL_SECONDS = 240; // hub caps proof lifetime at 300s
+const INVOCATION_TTL_SECONDS = 60;
+
+let cachedWorkerDid: string | null = null;
+
+async function fetchWorkerDid(): Promise<string> {
+  if (cachedWorkerDid) return cachedWorkerDid;
+
+  const res = await fetch(`${YOMA_SYNC_API_BASE}/.well-known/did.json`);
+  if (!res.ok) throw new Error(`Failed to fetch yoma worker DID: ${res.status}`);
+  const doc = await res.json();
+  const did = doc?.id;
+  if (typeof did !== 'string' || !did.startsWith('did:')) {
+    throw new Error('Malformed yoma worker DID document');
+  }
+  cachedWorkerDid = did;
+  return did;
+}
+
+async function linkAuthHeaders(userDid: string, workerDid: string): Promise<Record<string, string>> {
+  const mnemonic = secureLoad(authConstants.secretKey.ED_SIGNING_MNEMONIC);
+  if (!mnemonic) throw new Error('Signing mnemonic not available — please sign in again');
+
+  const { signer } = await signerFromMnemonic(String(mnemonic).trim(), userDid as SupportedDID);
+  const invocation = await createInvocation({
+    issuer: signer,
+    audience: workerDid,
+    capability: { can: 'yoma/link', with: 'ixo:yoma' },
+    expiration: Math.floor(Date.now() / 1000) + INVOCATION_TTL_SECONDS,
+    // Nonce fact → unique CID for same-second mints (Ed25519 is deterministic).
+    facts: [{ nonce: globalThis.crypto.randomUUID() }],
+  });
+
+  return {
+    Authorization: `Bearer ${await serializeInvocation(invocation)}`,
+    'X-Auth-Type': 'ucan',
+  };
+}
+
+function parseLinkResult(body: unknown): YomaLinkResult {
+  const { email, yomaId } = (body ?? {}) as { email?: unknown; yomaId?: unknown };
+  return {
+    email: typeof email === 'string' ? email : null,
+    yomaId: typeof yomaId === 'string' ? yomaId : null,
+  };
+}
+
+/** Cheap worker-side D1 read — costs no auth-hub quota. */
+export async function getLinkStatus(userDid: string): Promise<YomaLinkResult> {
+  const workerDid = await fetchWorkerDid();
+  const res = await fetch(`${YOMA_SYNC_API_BASE}/v1/link/status`, {
+    headers: await linkAuthHeaders(userDid, workerDid),
+  });
+  if (!res.ok) throw new Error(`Link status failed: ${res.status}`);
+  return parseLinkResult(await res.json());
+}
+
+/**
+ * Bind: delegate `auth/user/email` to the worker so it can fetch this DID's
+ * verified email from the auth hub and match it against Yoma's profiles.
+ * Idempotent server-side; the hub is consulted at most once per DID.
+ */
+export async function bindLink(userDid: string): Promise<YomaLinkResult> {
+  const workerDid = await fetchWorkerDid();
+  const address = userDid.split(':').at(2) ?? '';
+
+  const delegation = await mintDelegation({
+    userDid,
+    audience: workerDid,
+    capabilities: [{ can: 'auth/user/email', with: `ixo:auth-hub:user:${address}` }],
+    ttlSeconds: EMAIL_DELEGATION_TTL_SECONDS,
+  });
+
+  const res = await fetch(`${YOMA_SYNC_API_BASE}/v1/link/bind`, {
+    method: 'POST',
+    headers: { ...(await linkAuthHeaders(userDid, workerDid)), 'Content-Type': 'application/json' },
+    body: JSON.stringify({ delegation }),
+  });
+  if (!res.ok) throw new Error(`Link bind failed: ${res.status}`);
+  return parseLinkResult(await res.json());
+}

--- a/lib/yomaSync/config.ts
+++ b/lib/yomaSync/config.ts
@@ -1,0 +1,9 @@
+/**
+ * The Yoma opportunity-pull-synchronisation worker (the partner API Yoma
+ * calls) — distinct from the jambo worker. It hosts the jambo-facing
+ * DID ↔ Yoma link endpoints (/v1/link/*) and its did:web document.
+ */
+export const YOMA_SYNC_WORKER_URL = (process.env.NEXT_PUBLIC_YOMA_SYNC_WORKER_URL || '').trim().replace(/\/+$/, '');
+
+/** Browser-side base — proxied through a Next API route to avoid CORS. */
+export const YOMA_SYNC_API_BASE = '/api/yomaSync';

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,6 +9,7 @@ import { ReduxProvider } from '@store/provider';
 import { ThemeProvider } from '@providers/theme';
 import { AuthProvider } from '@providers/auth';
 import { BackgroundSetupProvider } from '@providers/backgroundSetup';
+import { YomaLinkProvider } from '@providers/yomaLink';
 import { ToastContainer } from '@components/Toast/Toast';
 import EmailNotificationPrompt from '@components/EmailNotifier/EmailNotificationPrompt';
 
@@ -18,9 +19,11 @@ function MyApp({ Component, pageProps }: AppProps) {
       <ThemeProvider>
         <AuthProvider>
           <BackgroundSetupProvider>
-            <Component {...pageProps} />
-            <EmailNotificationPrompt />
-            <ToastContainer />
+            <YomaLinkProvider>
+              <Component {...pageProps} />
+              <EmailNotificationPrompt />
+              <ToastContainer />
+            </YomaLinkProvider>
           </BackgroundSetupProvider>
         </AuthProvider>
       </ThemeProvider>

--- a/pages/api/yomaSync/[...path].ts
+++ b/pages/api/yomaSync/[...path].ts
@@ -1,0 +1,63 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+// Same shape as the jambo-worker proxy (pages/api/yomaWorker) — forwards to
+// the Yoma pull-synchronisation worker, which hosts the DID↔Yoma link
+// endpoints and its did:web document.
+const YOMA_SYNC_WORKER_URL = (process.env.NEXT_PUBLIC_YOMA_SYNC_WORKER_URL || '').trim().replace(/\/+$/, '');
+
+export const config = {
+  api: { bodyParser: false },
+};
+
+const HOP_BY_HOP_REQ = new Set(['host', 'connection', 'content-length', 'accept-encoding']);
+const HOP_BY_HOP_RES = new Set(['transfer-encoding', 'connection', 'content-encoding', 'content-length']);
+
+async function readBody(req: NextApiRequest): Promise<Buffer | undefined> {
+  if (req.method === 'GET' || req.method === 'HEAD') return undefined;
+  const chunks: Uint8Array[] = [];
+  // The cast sidesteps a Buffer/Uint8Array generics mismatch in newer
+  // @types/node — at runtime these are plain Buffers.
+  for await (const chunk of req) chunks.push(new Uint8Array(Buffer.from(chunk)));
+  return chunks.length ? Buffer.concat(chunks) : undefined;
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (!YOMA_SYNC_WORKER_URL) {
+    return res.status(500).json({ error: 'Yoma sync worker not configured (NEXT_PUBLIC_YOMA_SYNC_WORKER_URL missing)' });
+  }
+
+  const pathParts = (req.query.path as string[] | undefined) ?? [];
+  const qs = req.url?.includes('?') ? '?' + req.url.split('?')[1] : '';
+  // Next decodes the catch-all segments; re-encode so a segment containing an
+  // encoded "/" (or similar) can't address a different upstream route.
+  const targetUrl = `${YOMA_SYNC_WORKER_URL}/${pathParts.map(encodeURIComponent).join('/')}${qs}`;
+
+  const headers = new Headers();
+  for (const [k, v] of Object.entries(req.headers)) {
+    if (!v) continue;
+    if (HOP_BY_HOP_REQ.has(k.toLowerCase())) continue;
+    headers.set(k, Array.isArray(v) ? v.join(', ') : v);
+  }
+
+  try {
+    const body = await readBody(req);
+    const upstream = await fetch(targetUrl, {
+      method: req.method,
+      headers,
+      body: body as any,
+    });
+
+    res.status(upstream.status);
+    upstream.headers.forEach((v, k) => {
+      if (HOP_BY_HOP_RES.has(k.toLowerCase())) return;
+      res.setHeader(k, v);
+    });
+
+    const buf = Buffer.from(await upstream.arrayBuffer());
+    res.end(buf);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[yomaSync-proxy] error proxying', req.method, targetUrl, '-', message);
+    res.status(502).json({ error: `Yoma sync worker proxy error: ${message}` });
+  }
+}

--- a/pages/auth/callback.tsx
+++ b/pages/auth/callback.tsx
@@ -1,9 +1,10 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 
 import { useAuth } from '@hooks/useAuth';
 import { exchangeAuthCode } from 'lib/authHub/redirect';
 import { isDevBypass, getDevBypassSession } from 'lib/authHub/devBypass';
+import { takeReturnTo } from '@utils/returnTo';
 import { persistor } from '@store/index';
 import GradientBand from '@components/GradientBand/GradientBand';
 import AuthHeader from '@components/AuthHeader/AuthHeader';
@@ -13,8 +14,16 @@ export default function AuthCallbackPage() {
   const router = useRouter();
   const auth = useAuth();
   const [error, setError] = useState<string | null>(null);
+  const ranRef = useRef(false);
 
   useEffect(() => {
+    // The exchange code is single-use and gets stripped from the URL below —
+    // guard against React's double-invoke (StrictMode), whose second run
+    // would otherwise find no code and flash "Authentication Failed" while
+    // the first run's exchange is still succeeding.
+    if (ranRef.current) return;
+    ranRef.current = true;
+
     // Read code from URL and immediately strip it — prevents re-use on re-render/reload
     const params = new URLSearchParams(window.location.search);
     const code = params.get('code');
@@ -26,13 +35,15 @@ export default function AuthCallbackPage() {
 
     // Guard: if this code was already exchanged (e.g., page reload, bfcache), skip
     if (code && sessionStorage.getItem('ixo_code_used') === code) {
-      // Code was already exchanged — just navigate home
-      window.location.replace('/');
+      // Code was already exchanged — navigate to the saved deep link, or home
+      window.location.replace(takeReturnTo() ?? '/');
       return;
     }
 
     if (!code && !bypass) {
-      setError('No authorization code received');
+      // Opened directly with nothing to exchange (bookmark, stale tab) — not
+      // a failure, just bounce to the sign-in page.
+      window.location.replace('/auth');
       return;
     }
 
@@ -57,9 +68,11 @@ export default function AuthCallbackPage() {
         // otherwise the home page may see stale auth state and redirect back to /auth
         await persistor.flush();
 
-        // Use full page navigation (not router.replace) to ensure the home page
-        // re-initializes from persisted state — avoids client-side routing race conditions
-        window.location.replace('/');
+        // Use full page navigation (not router.replace) to ensure the target page
+        // re-initializes from persisted state — avoids client-side routing race
+        // conditions. Lands on the deep link saved before the auth redirect
+        // (e.g. a Yoma hand-off to /entities/<did>), or home when there is none.
+        window.location.replace(takeReturnTo() ?? '/');
       } catch (err) {
         console.error('Auth callback failed:', err);
         setError(err instanceof Error ? err.message : 'Authentication failed');

--- a/pages/auth/index.tsx
+++ b/pages/auth/index.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useRouter } from 'next/router';
 
 import GuestGuard from '@components/GuestGuard';
@@ -7,10 +7,16 @@ import Button, { BUTTON_BG_COLOR, BUTTON_BORDER_COLOR, BUTTON_COLOR, BUTTON_SIZE
 import { GRADIENT_COLORS } from '@constants/gradientColors';
 import { loginViaAuthHub } from 'lib/authHub/redirect';
 import { isDevBypass } from 'lib/authHub/devBypass';
+import { peekYref } from '@utils/yomaLink';
 
 export default function AuthPage() {
   const router = useRouter();
   const [isRedirecting, setIsRedirecting] = useState(false);
+  // sessionStorage is browser-only — read after mount to keep SSR happy.
+  const [fromYoma, setFromYoma] = useState(false);
+  useEffect(() => {
+    setFromYoma(peekYref() !== null);
+  }, []);
 
   function handleSignIn() {
     setIsRedirecting(true);
@@ -57,6 +63,21 @@ export default function AuthPage() {
           {hasError && (
             <p style={{ color: 'var(--error-color)', fontSize: '14px', textAlign: 'center', margin: 0 }}>
               {router.query.error_description?.toString() || router.query.error?.toString()}
+            </p>
+          )}
+
+          {fromYoma && (
+            <p
+              style={{
+                color: 'var(--text-secondary)',
+                fontSize: '14px',
+                textAlign: 'center',
+                margin: 0,
+                lineHeight: 1.5,
+              }}
+            >
+              You&apos;re joining from Yoma — please sign in with the <strong>same email</strong> you use on Yoma so
+              your progress counts towards your Yoma rewards.
             </p>
           )}
 

--- a/providers/auth.tsx
+++ b/providers/auth.tsx
@@ -6,6 +6,8 @@ import { secureSave, secureLoad, secureReset } from '@utils/storage';
 import { secret } from '@utils/secrets';
 import { logoutMatrixClient } from '@utils/matrix';
 import { cleanUrlString } from '@utils/url';
+import { clearReturnTo, saveReturnTo, suppressReturnTo } from '@utils/returnTo';
+import { clearLinkState, clearYref } from '@utils/yomaLink';
 import { signAndBroadcastWithSessionKey } from 'lib/authHub/signAndBroadcast';
 import type { AuthHubSessionData } from 'lib/authHub/redirect';
 import { store, persistor } from '@store/index';
@@ -60,6 +62,7 @@ export const AuthProvider = ({ children }: HTMLAttributes<HTMLDivElement>) => {
   const [address, setAddress] = useState<string | null>(null);
   const [did, setDid] = useState<string | null>(null);
   const [displayName, setDisplayName] = useState<string | null>(null);
+  const [email, setEmail] = useState<string | null>(null);
   const [sessionAuthenticatorId, setSessionAuthenticatorId] = useState<string | null>(null);
   const [matrixUserId, setMatrixUserId] = useState<string | null>(null);
   const [matrixRoomId, setMatrixRoomId] = useState<string | null>(null);
@@ -79,6 +82,7 @@ export const AuthProvider = ({ children }: HTMLAttributes<HTMLDivElement>) => {
     if (data.matrixUserId) secureSave(authConstants.secretKey.MATRIX_USER_ID, data.matrixUserId);
     if (data.matrixRoomId) secureSave(authConstants.secretKey.MATRIX_ROOM_ID, data.matrixRoomId);
     if (data.displayName) secureSave(authConstants.secretKey.DISPLAY_NAME, data.displayName);
+    if (data.email) secureSave(authConstants.secretKey.EMAIL, data.email);
     secureSave(authConstants.secretKey.SESSION_CREATED_AT, String(Date.now()));
   }
 
@@ -92,6 +96,7 @@ export const AuthProvider = ({ children }: HTMLAttributes<HTMLDivElement>) => {
     setAddress(null);
     setDid(null);
     setDisplayName(null);
+    setEmail(null);
     setSessionAuthenticatorId(null);
     setMatrixUserId(null);
     setMatrixRoomId(null);
@@ -147,6 +152,9 @@ export const AuthProvider = ({ children }: HTMLAttributes<HTMLDivElement>) => {
       setAddress(persistedAccount.address);
       setDid(persistedAccount.did);
       setDisplayName(persistedAccount.displayName ?? null);
+      // Optional — sessions created before the auth hub returned an email
+      // simply have none until the next login.
+      setEmail(persistedAccount.email ?? null);
       setSessionAuthenticatorId(persistedAccount.sessionAuthenticatorId ?? null);
       setMatrixUserId(persistedAccount.matrixUserId ?? null);
       setMatrixRoomId(persistedAccount.matrixRoomId ?? null);
@@ -163,6 +171,7 @@ export const AuthProvider = ({ children }: HTMLAttributes<HTMLDivElement>) => {
     setAddress(data.address);
     setDid(data.did);
     setDisplayName(data.displayName);
+    setEmail(data.email ?? null);
     setSessionAuthenticatorId(data.sessionAuthenticatorId);
     setMatrixUserId(data.matrixUserId);
     setMatrixRoomId(data.matrixRoomId);
@@ -175,6 +184,7 @@ export const AuthProvider = ({ children }: HTMLAttributes<HTMLDivElement>) => {
         signingMethod: 'session_key',
         sessionAuthenticatorId: data.sessionAuthenticatorId,
         displayName: data.displayName,
+        email: data.email ?? null,
         matrixUserId: data.matrixUserId,
         matrixRoomId: data.matrixRoomId,
       }),
@@ -240,7 +250,26 @@ export const AuthProvider = ({ children }: HTMLAttributes<HTMLDivElement>) => {
     }
   }, []);
 
-  const logout = useCallback(async () => {
+  const logout = useCallback(async (options?: { preserveReturnTo?: boolean }) => {
+    const preserveReturnTo = options?.preserveReturnTo ?? false;
+    if (preserveReturnTo) {
+      // "Switch account" logout (Yoma wrong-account prompt): the next sign-in
+      // SHOULD land back on this page, so save it explicitly and leave the
+      // yref hand-off marker in place for the re-comparison. Only the
+      // previous account's link cache is wiped.
+      saveReturnTo(window.location.pathname + window.location.search);
+    } else {
+      // Clean-break logout: before any state flips, wipe the saved deep link
+      // and block re-saves — AuthGuard reacts to the logged-out flip below
+      // and would otherwise capture the page the user logged out from (see
+      // utils/returnTo.ts). Also drop any Yoma hand-off marker: on a shared
+      // computer the next person must not inherit it.
+      suppressReturnTo();
+      clearYref();
+    }
+    // Either way, the per-account Yoma link cache and session-check flag
+    // belong to the account signing out — never to the next login.
+    clearLinkState();
     setIsLoggingOut(true);
 
     // Overall safety net: never let matrix cleanup block the redirect for more than 8s.
@@ -259,6 +288,12 @@ export const AuthProvider = ({ children }: HTMLAttributes<HTMLDivElement>) => {
       console.warn('persistor.purge failed (continuing):', err);
     }
 
+    // Clean break only — drop any deep link AuthGuard saved while this
+    // page's auth state flipped (e.g. /settings), so the next sign-in starts
+    // fresh instead of resuming where the user logged out. The switch-account
+    // variant deliberately keeps its explicitly saved return path.
+    if (!preserveReturnTo) clearReturnTo();
+
     window.location.href = '/auth';
   }, []);
 
@@ -268,6 +303,7 @@ export const AuthProvider = ({ children }: HTMLAttributes<HTMLDivElement>) => {
     address,
     did,
     displayName,
+    email,
     sessionAuthenticatorId,
     matrixUserId,
     matrixRoomId,

--- a/providers/yomaLink.tsx
+++ b/providers/yomaLink.tsx
@@ -1,0 +1,186 @@
+import { HTMLAttributes, useEffect, useRef, useState } from 'react';
+import { useRouter } from 'next/router';
+
+import { useAuth } from '@hooks/useAuth';
+import { successToast } from '@components/Toast/Toast';
+import { bindLink, getLinkStatus } from 'lib/yomaSync/client';
+import {
+  clearYref,
+  getCachedLink,
+  markCheckedThisSession,
+  peekYref,
+  saveYref,
+  setCachedLink,
+  wasCheckedThisSession,
+  type YomaLinkState,
+} from '@utils/yomaLink';
+
+/**
+ * Root-mounted DID ↔ Yoma link flow. Two responsibilities:
+ *
+ * 1. Capture the `?yref=<partnerUserId>` hand-off marker the yoma worker
+ *    appends to its redirect — on ANY page, logged in or not — stash it in
+ *    sessionStorage (it survives the auth-hub round trip) and strip it from
+ *    the URL so a copied/shared link doesn't carry someone's marker.
+ * 2. Once logged in: silently verify the account's email with the yoma
+ *    worker (UCAN bind, once per DID ever — the worker caches it) and match
+ *    it to a Yoma account. Then, if a hand-off marker is present, compare it
+ *    with the account's own yomaId:
+ *      - match    → "Yoma account connected" toast, marker cleared
+ *      - mismatch → modal offering "switch account" logout or continue
+ *
+ * Everything is soft-fail: any error is swallowed and retried next session —
+ * this flow must never disturb a youth completing an opportunity.
+ */
+
+export const YomaLinkProvider = ({ children }: HTMLAttributes<HTMLDivElement>) => {
+  const { isLoggedIn, isLoading, did, logout } = useAuth();
+  const router = useRouter();
+  const [mismatch, setMismatch] = useState(false);
+  const [loggingOut, setLoggingOut] = useState(false);
+  const runningRef = useRef(false);
+
+  // 1. Capture + strip the hand-off marker on every route change.
+  useEffect(() => {
+    if (!router.isReady) return;
+    const url = new URL(window.location.href);
+    const yref = url.searchParams.get('yref');
+    if (!yref) return;
+    saveYref(yref);
+    url.searchParams.delete('yref');
+    window.history.replaceState(window.history.state, '', url.pathname + url.search + url.hash);
+  }, [router.isReady, router.asPath]);
+
+  // 2. Silent link check after login (and on arrival with a live session).
+  useEffect(() => {
+    if (isLoading || !isLoggedIn || !did || !router.isReady) return;
+    if (runningRef.current) return;
+
+    const yref = peekYref();
+    // Once per browser session unless a hand-off marker demands a comparison.
+    if (!yref && wasCheckedThisSession(did)) return;
+
+    runningRef.current = true;
+    (async () => {
+      try {
+        let link: YomaLinkState | null = getCachedLink(did);
+
+        // A completed link is permanent — only hit the network when we don't
+        // know of one yet. status is a cheap D1 read; bind (which costs one
+        // rate-limited auth-hub email read, once per DID ever) only runs
+        // while the worker has no verified email for this DID.
+        if (!link?.yomaId) {
+          link = await getLinkStatus(did);
+          if (!link.email) link = await bindLink(did);
+          setCachedLink(did, link);
+        }
+        markCheckedThisSession(did);
+
+        if (yref) {
+          if (link.yomaId && link.yomaId === yref) {
+            clearYref();
+            successToast('Yoma account connected');
+          } else {
+            // Wrong account OR an email that matches no Yoma profile — either
+            // way this sign-in isn't the account the hand-off was for.
+            setMismatch(true);
+          }
+        }
+      } catch (err) {
+        // Soft-fail by design (worker down, hub rate-limited, legacy dev
+        // account) — the check re-runs next session.
+        console.warn('Yoma link check failed (will retry next session):', err);
+      } finally {
+        runningRef.current = false;
+      }
+    })();
+  }, [isLoading, isLoggedIn, did, router.isReady]);
+
+  function handleContinue() {
+    // The user owns the decision — drop the marker so it never nags again.
+    clearYref();
+    setMismatch(false);
+  }
+
+  function handleSwitchAccount() {
+    setLoggingOut(true);
+    // preserveReturnTo keeps the deep link AND the yref marker, so after
+    // signing in with the right account the user lands back here and the
+    // comparison re-runs (and connects).
+    void logout({ preserveReturnTo: true });
+  }
+
+  return (
+    <>
+      {children}
+      {mismatch && (
+        <div
+          style={{
+            position: 'fixed',
+            inset: 0,
+            zIndex: 2200,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+            backgroundColor: 'rgba(0, 0, 0, 0.7)',
+            backdropFilter: 'blur(4px)',
+          }}
+        >
+          <div
+            style={{
+              backgroundColor: 'var(--bg-primary, #1a1a2e)',
+              borderRadius: 16,
+              padding: '32px 28px',
+              maxWidth: 360,
+              width: '90%',
+              textAlign: 'center',
+              display: 'flex',
+              flexDirection: 'column',
+              gap: 16,
+              boxShadow: '0 8px 32px rgba(0, 0, 0, 0.4)',
+            }}
+          >
+            <p style={{ color: 'var(--text-primary)', fontSize: 16, fontWeight: 600, margin: 0 }}>
+              Different Yoma account
+            </p>
+            <p style={{ color: 'var(--text-secondary)', fontSize: 14, margin: 0, lineHeight: 1.5 }}>
+              You came here from Yoma, but the account you&apos;re signed in with uses a different email than your Yoma
+              account. To earn your Yoma reward, sign in with the same email you use on Yoma.
+            </p>
+            <button
+              onClick={handleSwitchAccount}
+              disabled={loggingOut}
+              style={{
+                padding: '12px 20px',
+                borderRadius: 8,
+                border: 'none',
+                backgroundColor: '#3E9B4F',
+                color: 'white',
+                cursor: 'pointer',
+                fontSize: 15,
+                fontWeight: 600,
+              }}
+            >
+              {loggingOut ? 'Signing out…' : 'Log out and switch account'}
+            </button>
+            <button
+              onClick={handleContinue}
+              disabled={loggingOut}
+              style={{
+                padding: '10px 20px',
+                borderRadius: 8,
+                border: '1px solid var(--border-color)',
+                background: 'none',
+                color: 'var(--text-primary)',
+                cursor: 'pointer',
+                fontSize: 14,
+              }}
+            >
+              Continue with this account
+            </button>
+          </div>
+        </div>
+      )}
+    </>
+  );
+};

--- a/screens/settings.tsx
+++ b/screens/settings.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, ReactNode } from 'react';
+import { useState, useCallback, useEffect, ReactNode } from 'react';
 import { useRouter } from 'next/router';
 
 import Header from '@components/Header/Header';
@@ -14,6 +14,7 @@ import {
   generateUserRoomAliasFromAddress,
 } from '@utils/matrix';
 import { cleanUrlString } from '@utils/url';
+import { getCachedLink, type YomaLinkState } from '@utils/yomaLink';
 
 type SecretKey = 'password' | 'passphrase';
 
@@ -29,6 +30,13 @@ export default function SettingsScreen() {
   const userId = secret.userId;
   const baseUrl = secret.baseUrl;
   const accessToken = secret.accessToken;
+
+  // Populated by the root YomaLinkProvider's silent check; storage is
+  // browser-only, so read after mount to keep SSR/hydration happy.
+  const [yomaLink, setYomaLink] = useState<YomaLinkState | null>(null);
+  useEffect(() => {
+    if (did) setYomaLink(getCachedLink(did));
+  }, [did]);
 
   const goBack = useCallback(() => {
     if (typeof window !== 'undefined' && window.history.length > 1) {
@@ -235,6 +243,41 @@ export default function SettingsScreen() {
               <span style={{ fontSize: '13px', color: 'var(--text-secondary)' }}>—</span>
             )}
           </Row>
+        </div>
+
+        <h1
+          style={{
+            margin: '24px 0 8px',
+            fontSize: '1.1rem',
+            fontWeight: 500,
+            color: 'var(--text-primary)',
+          }}
+        >
+          Yoma Account
+        </h1>
+
+        <div style={{ padding: '0 4px' }}>
+          {yomaLink?.yomaId ? (
+            <p style={{ margin: 0, fontSize: '13px', color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+              <span style={{ color: '#3E9B4F', fontWeight: 600 }}>Connected</span> — your completions count towards
+              your Yoma rewards.
+              {yomaLink.email ? (
+                <>
+                  {' '}
+                  Linked email: <span style={{ color: 'var(--text-primary)' }}>{yomaLink.email}</span>
+                </>
+              ) : null}
+            </p>
+          ) : yomaLink?.email ? (
+            <p style={{ margin: 0, fontSize: '13px', color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+              Your email <span style={{ color: 'var(--text-primary)' }}>{yomaLink.email}</span> is verified, but no
+              Yoma account with this email is linked yet. Make sure your Yoma account uses the same email.
+            </p>
+          ) : (
+            <p style={{ margin: 0, fontSize: '13px', color: 'var(--text-secondary)', lineHeight: 1.5 }}>
+              Not connected to a Yoma account.
+            </p>
+          )}
         </div>
 
         <h1

--- a/store/slices/accountSlice.ts
+++ b/store/slices/accountSlice.ts
@@ -6,6 +6,8 @@ interface AccountState {
   signingMethod: 'session_key' | undefined;
   sessionAuthenticatorId: string | null;
   displayName: string | null;
+  /** Optional — sessions created before the auth hub returned it have none. */
+  email?: string | null;
   matrixUserId: string | null;
   matrixRoomId: string | null;
 }
@@ -16,6 +18,7 @@ const initialState: AccountState = {
   signingMethod: undefined,
   sessionAuthenticatorId: null,
   displayName: null,
+  email: null,
   matrixUserId: null,
   matrixRoomId: null,
 };
@@ -32,6 +35,7 @@ const accountSlice = createSlice({
         signingMethod: 'session_key';
         sessionAuthenticatorId: string | null;
         displayName: string | null;
+        email?: string | null;
         matrixUserId: string | null;
         matrixRoomId: string | null;
       }>,
@@ -41,6 +45,7 @@ const accountSlice = createSlice({
       state.signingMethod = action.payload.signingMethod;
       state.sessionAuthenticatorId = action.payload.sessionAuthenticatorId;
       state.displayName = action.payload.displayName;
+      state.email = action.payload.email ?? null;
       state.matrixUserId = action.payload.matrixUserId;
       state.matrixRoomId = action.payload.matrixRoomId;
     },

--- a/utils/returnTo.ts
+++ b/utils/returnTo.ts
@@ -1,0 +1,72 @@
+const KEY = 'ixo_return_to';
+// Deep links older than this are dropped — a youth who abandoned login
+// yesterday shouldn't be teleported to a stale page on today's sign-in.
+const MAX_AGE_MS = 30 * 60 * 1000;
+
+// Once logout starts, AuthGuard still fires on the logged-out state flip and
+// would re-save the page the user logged out FROM — its passive effect can
+// run after logout's own clear. This flag outlives that race: logout ends in
+// a full page navigation, so the module (and the flag) resets naturally on
+// the next page load.
+let suppressed = false;
+
+/**
+ * Remembers where a logged-out visitor was heading so the auth flow can take
+ * them back after sign-in (e.g. a Yoma hand-off deep link to
+ * /entities/<did>). sessionStorage survives the full-page redirect round trip
+ * to the auth hub within the same tab.
+ */
+export function saveReturnTo(path: string): void {
+  if (suppressed) return;
+  // Internal app paths only (no protocol-relative //host), and never the
+  // auth pages themselves or the home default.
+  if (!path.startsWith('/') || path.startsWith('//')) return;
+  if (path === '/' || path.startsWith('/auth')) return;
+  // An unhydrated dynamic-route pattern ("/entities/[entityId]") is not a
+  // real destination — never save it.
+  if (path.includes('[')) return;
+  try {
+    sessionStorage.setItem(KEY, JSON.stringify({ path, ts: Date.now() }));
+  } catch {
+    // Storage unavailable (private mode etc.) — losing the deep link is fine.
+  }
+}
+
+/**
+ * Drops any saved path. Called on explicit logout — signing out is a clean
+ * break, so the next sign-in must start fresh instead of resuming the page
+ * the user happened to be on when they logged out.
+ */
+export function clearReturnTo(): void {
+  try {
+    sessionStorage.removeItem(KEY);
+  } catch {
+    // Storage unavailable — nothing to clear.
+  }
+}
+
+/**
+ * Call at the START of logout: clears any saved path AND blocks new saves for
+ * the remainder of this page instance, so the guard's logged-out effect can't
+ * re-save the current page mid-teardown.
+ */
+export function suppressReturnTo(): void {
+  suppressed = true;
+  clearReturnTo();
+}
+
+/** Reads and clears the saved path; null when absent, expired, or invalid. */
+export function takeReturnTo(): string | null {
+  try {
+    const raw = sessionStorage.getItem(KEY);
+    if (!raw) return null;
+    sessionStorage.removeItem(KEY);
+    const { path, ts } = JSON.parse(raw) as { path?: unknown; ts?: unknown };
+    if (typeof path !== 'string' || !path.startsWith('/') || path.startsWith('//')) return null;
+    if (path.includes('[')) return null; // stale unhydrated route pattern
+    if (typeof ts !== 'number' || Date.now() - ts > MAX_AGE_MS) return null;
+    return path;
+  } catch {
+    return null;
+  }
+}

--- a/utils/yomaLink.ts
+++ b/utils/yomaLink.ts
@@ -1,0 +1,115 @@
+/**
+ * Client-side state for the DID ↔ Yoma account link flow.
+ *
+ * - `yref` — the hand-off marker the yoma worker appends to its redirect
+ *   (`/entities/<did>?yref=<partnerUserId>`). It identifies WHICH Yoma user
+ *   this hand-off was for; after login we compare it against the logged-in
+ *   account's own `yomaId` to detect a wrong-account sign-in. Kept in
+ *   sessionStorage so it survives the same-tab auth-hub round trip.
+ * - Link cache — the last `{ email, yomaId }` the worker reported, keyed by
+ *   DID, so the root check doesn't re-query on every page. A completed link
+ *   (`yomaId` set) is permanent server-side; an incomplete one is re-checked
+ *   once per browser session (the Yoma match can complete server-side later).
+ *
+ * Everything here is cleared on logout — a public PC must not leak the
+ * previous user's link state (or resume their hand-off) to the next login.
+ */
+
+const YREF_KEY = 'ixo_yoma_yref';
+const LINK_CACHE_KEY = 'ixo_yoma_link';
+const CHECKED_KEY = 'ixo_yoma_checked';
+// A hand-off marker older than a day is stale — drop rather than confuse.
+const YREF_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+export interface YomaLinkState {
+  email: string | null;
+  yomaId: string | null;
+}
+
+export function saveYref(yref: string): void {
+  if (!yref) return;
+  try {
+    sessionStorage.setItem(YREF_KEY, JSON.stringify({ yref, ts: Date.now() }));
+  } catch {
+    // Storage unavailable — losing the marker only skips the mismatch check.
+  }
+}
+
+/** Reads without clearing — the marker stays until matched, dismissed, or logout. */
+export function peekYref(): string | null {
+  try {
+    const raw = sessionStorage.getItem(YREF_KEY);
+    if (!raw) return null;
+    const { yref, ts } = JSON.parse(raw) as { yref?: unknown; ts?: unknown };
+    if (typeof yref !== 'string' || !yref) return null;
+    if (typeof ts !== 'number' || Date.now() - ts > YREF_MAX_AGE_MS) {
+      sessionStorage.removeItem(YREF_KEY);
+      return null;
+    }
+    return yref;
+  } catch {
+    return null;
+  }
+}
+
+export function clearYref(): void {
+  try {
+    sessionStorage.removeItem(YREF_KEY);
+  } catch {
+    // Storage unavailable — nothing to clear.
+  }
+}
+
+export function getCachedLink(did: string): YomaLinkState | null {
+  try {
+    const raw = localStorage.getItem(LINK_CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as { did?: unknown; email?: unknown; yomaId?: unknown };
+    if (parsed.did !== did) return null; // another account's cache — ignore
+    return {
+      email: typeof parsed.email === 'string' ? parsed.email : null,
+      yomaId: typeof parsed.yomaId === 'string' ? parsed.yomaId : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function setCachedLink(did: string, link: YomaLinkState): void {
+  try {
+    localStorage.setItem(LINK_CACHE_KEY, JSON.stringify({ did, ...link, ts: Date.now() }));
+  } catch {
+    // Storage unavailable — the check just re-runs next session.
+  }
+}
+
+/** Once-per-browser-session guard for the root status/bind check. */
+export function wasCheckedThisSession(did: string): boolean {
+  try {
+    return sessionStorage.getItem(CHECKED_KEY) === did;
+  } catch {
+    return false;
+  }
+}
+
+export function markCheckedThisSession(did: string): void {
+  try {
+    sessionStorage.setItem(CHECKED_KEY, did);
+  } catch {
+    // Storage unavailable — worst case the check repeats (it's cheap).
+  }
+}
+
+/**
+ * Clears the link cache + session-check flag. Called on EVERY logout. The
+ * yref is cleared separately — a "switch account" logout keeps it so the
+ * hand-off comparison re-runs for the next sign-in.
+ */
+export function clearLinkState(): void {
+  try {
+    localStorage.removeItem(LINK_CACHE_KEY);
+    sessionStorage.removeItem(CHECKED_KEY);
+  } catch {
+    // Storage unavailable — nothing to clear.
+  }
+}


### PR DESCRIPTION
## What

**Deep-link return** — a Yoma hand-off now lands the youth on the opportunity page after login instead of home:
- `utils/returnTo.ts`: return path saved by AuthGuard before the `/auth` redirect (after `router.isReady`, so dynamic routes save the real URL) and consumed by the auth callback.
- Callback hardening: StrictMode double-invoke guard — no more transient "Authentication Failed" flash after a successful login; direct no-code visits bounce silently to `/auth`.
- Clean-state logout: signing out from `/settings` no longer resumes `/settings` on the next login (module-level save suppression beats the guard's late passive-effect re-save).

**DID ↔ Yoma account link** — silent, email-verified:
- Root `YomaLinkProvider`: captures the `?yref=<partnerUserId>` marker from the yoma sync worker's redirect on any page (strips it from the URL), then after login runs status → bind against the worker with UCANs (`yoma/link` invocation + `auth/user/email` delegation — the worker fetches the verified email from the auth hub; the frontend never asserts an email). Match → **"Yoma account connected"** toast; mismatch → modal with **Log out and switch** (keeps deep link + marker) / **Continue** (clears it).
- Once-per-session check with per-DID cache; all Yoma link state cleared on every logout (shared-computer safe). Every failure is soft: console-warned, retried next session, never user-visible — so an env whose worker isn't deployed (mainnet today) is a silent no-op.
- Session `email` from the auth-hub exchange (display only); settings gains a **Yoma Account** section; `/auth` shows a "use the same email as on Yoma" hint when arriving from a hand-off.
- New `/api/yomaSync` proxy + `NEXT_PUBLIC_YOMA_SYNC_WORKER_URL` (testnet: `https://test.sync.yoma.ixo.earth`, mainnet: `https://sync.yoma.ixo.earth` — set in Vercel).

## Tested

Full flow verified end-to-end against the deployed testnet worker + live auth hub: hand-off → sign-in hint → login → toast → settings Connected (D1 link row verified server-side), wrong-account hand-off → mismatch modal, clean logout, error-flash and deep-link regressions re-checked. `tsc` clean for changed files; `next build` succeeds.

Authored by: Michael Pretorius <michael@ixo.world>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/ixofoundation/codesmith/jambo/pr/75"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789742544&installation_model_id=432277&pr_number=75&repository=ixofoundation%2Fjambo&return_to=https%3A%2F%2Fgithub.com%2Fixofoundation%2Fjambo%2Fpull%2F75&signature=043b6c8f5d1f2938293a74d274f32d2e42d07a47680f64b8e9148696e26fc125"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->